### PR TITLE
feat(skills): Agent-driven setup and build skills

### DIFF
--- a/skills/deft-build/SKILL.md
+++ b/skills/deft-build/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: deft-build
+description: >
+  Build a project from a SPECIFICATION.md following Deft framework standards.
+  Use after deft-setup has generated the spec, or when the user has a
+  SPECIFICATION.md ready to implement. Handles scaffolding, implementation,
+  testing, and quality checks phase by phase.
+---
+
+# Deft Build
+
+Implements a project from its SPECIFICATION.md following deft standards.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+## When to Use
+
+- After `/deft-setup` completes and generates SPECIFICATION.md
+- User says "build this", "implement the spec", or "start building"
+- Resuming a partially-built project that has a spec
+
+## File Reading
+
+- ! Read in order, lazy load:
+  1. `./SPECIFICATION.md` — what to build (required)
+  2. `./PROJECT.md` — project config, tech stack, strategy
+  3. `~/.config/deft/USER.md` — user preferences (highest precedence)
+  4. `deft/main.md` — framework guidelines
+  5. `deft/coding/coding.md` — coding standards
+  6. `deft/coding/testing.md` — testing requirements
+  7. `deft/languages/{language}.md` — only for languages this project uses
+- ⊗ Read all language/interface/tool files upfront
+
+## Rule Precedence
+
+```
+USER.md          ← HIGHEST
+PROJECT.md       ← Project rules
+{language}.md    ← Language standards
+coding.md        ← General coding
+main.md          ← Framework defaults
+SPECIFICATION.md ← LOWEST
+```
+
+- ! If USER.md contradicts any lower file, USER.md wins
+
+## Build Process
+
+### Step 1: Understand the Spec
+
+- ! Read SPECIFICATION.md
+- ! Identify phases, dependencies, starting point
+- ! Present brief summary to user:
+
+> "Here's what I see: Phase 1: {name} ({N} tasks), Phase 2: {name} (depends on Phase 1). I'll start with Phase 1. Ready?"
+
+### Step 2: Build Phase by Phase
+
+For each phase:
+
+1. ! **Scaffold** — file structure, dependencies, config
+2. ! **Test first** — write tests before implementation (TDD)
+3. ! **Implement** — make tests pass, following deft coding standards
+4. ! **Verify** — run `task check`, fix any issues
+5. ! **Checkpoint** — tell user what's done, what's next
+
+- ⊗ Move to next phase until current phase passes all checks
+
+### Step 3: Quality Gates
+
+After EVERY phase:
+
+```bash
+task check          # Format, lint, type check, test, coverage
+task test:coverage  # ≥85% or PROJECT.md override
+```
+
+- ! Phase is NOT done until `task check` passes
+- ⊗ Skip quality gates or claim they passed without running
+
+## Coding Standards (Summary)
+
+Read full files when you need detail:
+
+- ! TDD: write tests first — implementation incomplete without passing tests
+- ! Coverage: ≥85% lines, functions, branches, statements
+- ~ Files: <300 lines ideal, <500 recommended, ! <1000 max
+- ~ Naming: hyphens for filenames unless language idiom dictates otherwise
+- ! Contracts first: define interfaces/types before implementation
+- ! Secrets: in `secrets/` dir with `.example` templates; ⊗ secrets in code
+- ! Commits: Conventional Commits format; ! run `task check` before every commit
+
+See `deft/coding/coding.md` and `deft/coding/testing.md` for full rules.
+
+## Commit Strategy
+
+- ~ Commit after each meaningful unit of work (per subphase or task)
+- ! Run `task check` before committing
+- ⊗ Claim checks passed without running them
+
+```
+feat(phase-1): scaffold project structure
+feat(phase-1): implement core data models with tests
+feat(phase-2): add REST API endpoints with integration tests
+```
+
+## Error Recovery
+
+- ! Tests fail → fix them; ⊗ skip or weaken assertions
+- ! Coverage drops → write more tests; ⊗ exclude files
+- ! Lint/type errors → fix them; ≉ add ignore comments without documented reason
+- ! Spec ambiguous → ask user; ⊗ guess
+- ! Spec needs changes → propose, get approval, update SPECIFICATION.md first
+
+## Completion
+
+- ! When all phases pass and `task check` is green:
+
+> "The project is built and all quality checks pass. Describe any new features you'd like to add — I'll follow the deft standards we've set up."
+
+## Anti-Patterns
+
+- ⊗ Skip tests or write them after implementation
+- ⊗ Ignore `task check` failures
+- ⊗ Implement things not in spec without asking
+- ⊗ Read every deft file upfront
+- ⊗ Move to next phase before current passes checks
+- ⊗ Make commits without running `task check`

--- a/skills/deft-setup/SKILL.md
+++ b/skills/deft-setup/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: deft-setup
+description: >
+  Set up a new project with Deft framework standards. Use when the user wants
+  to bootstrap user preferences, configure a project, or generate a project
+  specification. Walks through setup conversationally — no separate CLI needed.
+---
+
+# Deft Setup
+
+Agent-driven alternative to `deft/run bootstrap && deft/run project && deft/run spec`.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+## When to Use
+
+- User says "set up deft", "configure deft", or "bootstrap my project"
+- User asks to create USER.md, PROJECT.md, or SPECIFICATION.md
+- User clones a deft-enabled repo for the first time with no config
+
+## Agent Behavior
+
+**Flow:**
+- ! Start asking immediately — everything you need is in THIS file
+- ⊗ Explore the codebase, read framework files, or gather context before asking
+- ? Read `deft/main.md` or language files LATER when generating output
+
+**Interaction:**
+- ~ Use structured question tools when available (AskQuestion, question picker, multi-choice UI)
+- ~ Fall back to numbered text options if no structured tool exists
+- ⊗ Present choices as plain text when a structured tool is available
+
+**Defaults:**
+- ! Communicate that deft ships with best-in-class standards for 20+ languages
+- ! Frame setup as "tell me your overrides" — not "configure everything"
+- ~ "Deft has solid opinions on how code should be written and tested — I just need a few things about you and your project."
+
+**Adapt to Technical Level:**
+- ! First question gauges whether user is technical or non-technical
+- ! Technical user: ask about languages, strategy, coverage directly — they'll have opinions
+- ! Non-technical user: skip jargon, use sensible defaults, ask about what they're building not how
+- ⊗ Ask non-technical users about coverage thresholds, strategies, or framework choices
+
+## Available Languages
+
+C, C++, C#, Dart, Delphi, Elixir, Go, Java, JavaScript, Julia, Kotlin,
+Python, R, Rust, SQL, Swift, TypeScript, VHDL, Visual Basic, Zig, 6502-DASM
+
+- ? Read `deft/languages/{name}.md` when generating output — not before asking
+
+## Available Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| **default** | Structured interview → PRD → SPECIFICATION (Recommended) |
+| **brownfield** | Analyze existing codebase before adding features |
+| **discuss** | Front-load decisions and alignment before planning |
+| **research** | Investigate the domain before planning |
+| **speckit** | Five-phase spec-driven workflow (GitHub spec-kit inspired) |
+
+---
+
+## Phase 1 — User Preferences (USER.md)
+
+**Goal:** Personal preferences file. Highest precedence in deft rule hierarchy.
+
+- ~ Skip if `~/.config/deft/USER.md` exists and user doesn't want to overwrite
+- ⊗ Scan filesystem beyond checking that one path
+
+### Opening Question
+
+- ! Gauge technical level first:
+  - **"I'm technical — ask me everything"**
+  - **"I have some opinions but keep it simple"**
+  - **"Just pick good defaults — I care about the product, not the tools"**
+- ~ Use structured choice tool if available
+
+### Technical Users — Ask Together
+
+- ! Batch these in one message:
+  1. **Name** — what to call them
+  2. **Languages** — show list above
+  3. **Strategy** — show table above, recommend "default"
+  4. **Coverage threshold** — default 85%, ask if different
+  5. **Custom rules** — optional overrides
+
+### Non-Technical Users — Minimal
+
+- ! Ask only:
+  1. **Name**
+  2. **What are you building?** — infer everything else
+- ! Set defaults: strategy = "default", coverage = 85%
+- ~ Pick languages based on project type (web → TypeScript, API → Python/Go, mobile → Swift/Kotlin)
+
+### Output Path
+
+`~/.config/deft/USER.md` (or `$DEFT_USER_PATH`). Create parent dirs as needed.
+
+### Template
+
+```markdown
+# User Preferences
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+**Rule Precedence**: This file has HIGHEST precedence — overrides all other deft rules.
+Only add items here that **override or extend** the defaults in `deft/main.md`.
+
+## Name
+
+Address the user as: **{name}**
+
+## Overrides
+
+**Primary Languages**:
+- {language 1}
+- {language 2}
+
+**Default Strategy**: [{strategy name}](../strategies/{strategy-file}.md)
+
+{If coverage != 85: "**Coverage**: ! ≥{N}% test coverage"}
+
+## Custom Rules
+
+{custom rules or "No custom rules defined yet."}
+
+---
+
+**Note**: Edit this file anytime to update your preferences.
+**See**: [../main.md](../main.md) for framework defaults.
+```
+
+### Then
+
+- ~ Ask if user wants to continue to Phase 2 (project configuration)
+
+---
+
+## Phase 2 — Project Configuration (PROJECT.md)
+
+**Goal:** Project-specific configuration — tech stack, type, quality standards.
+
+- ~ Skip if `./PROJECT.md` exists and user doesn't want to replace
+
+### Inference
+
+- ! NOW infer from codebase — look for `package.json`, `go.mod`, `requirements.txt`, `Cargo.toml`, `pyproject.toml`, `*.csproj`
+- ! Present inferences and confirm — don't ask blind
+
+### Technical Users — Present and Confirm
+
+- ! Batch:
+  1. **Project name** — infer from directory, confirm
+  2. **Project type** — CLI, TUI, REST API, Web App, Library, other
+  3. **Languages** — detected + confirm
+  4. **Tech stack** — frameworks, libraries
+  5. **Strategy** — default to Phase 1 choice
+  6. **Coverage** — default 85%
+
+### Non-Technical Users — Summarize and Confirm
+
+- ! Detect and present summary: "Based on your project: {name} ({type}), built with {stack}. Look right?"
+- ⊗ Ask about strategy or coverage — use Phase 1 defaults
+
+### Output Path
+
+`./PROJECT.md` (or `$DEFT_PROJECT_PATH`).
+
+### Template
+
+```markdown
+# {Project Name} Project Guidelines
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+Only specify items here that **override or extend** the deft defaults.
+
+**See also**: [deft/main.md](deft/main.md) | {language links}
+
+## Project Configuration
+
+**Tech Stack**: {project type} using {languages}{tech stack details}
+
+## Strategy
+
+Use [{strategy name}](deft/strategies/{strategy-file}.md) for this project.
+
+## Workflow
+
+```bash
+task check         # Pre-commit gate
+task test:coverage # Coverage target
+task build         # Build project
+task clean         # Clean artifacts
+```
+
+## Standards
+
+**Quality:**
+- ! Run `task check` before every commit
+- ! Achieve ≥{coverage}% coverage overall + per-module
+- ! Store secrets in `secrets/` dir
+- ~ Provide `.example` templates for secrets
+
+## Project-Specific Rules
+
+{Any rules the user specified, or "(Add your custom rules here)"}
+
+---
+
+**Generated by**: deft-setup skill
+**Date**: {YYYY-MM-DD}
+```
+
+### Then
+
+- ~ Ask if user wants to continue to Phase 3 (specification)
+
+---
+
+## Phase 3 — Specification (SPECIFICATION.md)
+
+**Goal:** Interview user about what to build, generate implementable spec.
+No intermediate PRD.md needed — already in conversation.
+
+- ~ Skip if user already has a SPECIFICATION.md they're happy with
+
+### Interview Process
+
+Per `deft/templates/make-spec.md`:
+
+- ! Ask what to build and features first
+- ! Ask **ONE** focused, non-trivial question per step
+- ~ Provide numbered options with an "other" choice
+- ! Mark which option is RECOMMENDED
+- ⊗ Ask multiple questions at once
+- ⊗ Make assumptions without clarifying
+- ~ Use structured question tools for each interview question
+
+**Question Areas:**
+- ! Missing decisions (language, framework, deployment)
+- ! Edge cases (errors, boundaries, failure modes)
+- ! Implementation details (architecture, patterns, libraries)
+- ! Requirements (performance, security, scalability)
+- ! UX/constraints (users, timeline, compatibility)
+- ! Tradeoffs (simplicity vs features, speed vs safety)
+
+**Non-Technical Users:**
+- ~ Adjust vocabulary: "How do you want to store data?" not "What database engine?"
+- ~ "Will other apps talk to this?" not "REST or GraphQL?"
+
+**Completion:**
+- ! Continue until little ambiguity remains
+- ! Spec must be comprehensive enough to implement
+
+### Output
+
+1. ! Write `./vbrief/specification.vbrief.json` with `status: draft`
+2. ! Summarize decisions, ask user to review
+3. ! On approval, update `status` to `approved`
+4. ! Generate `./SPECIFICATION.md` (run `task spec:render` if available, else directly)
+
+**Spec Structure:**
+- ! Overview, Requirements, Architecture
+- ! Implementation Plan: Phases → Subphases → Tasks
+- ! Explicit dependency mapping between phases
+- ~ Tasks designed for parallel work by multiple agents
+- ! Testing Strategy and Deployment
+- ⊗ Write code — specification only
+
+### Handoff to deft-build
+
+- ! Offer to start building: "Your spec is ready. Want me to start building it now?"
+- ~ If platform supports skill invocation, invoke `/deft-build`
+- ⊗ Leave user with a dead end — always offer the next step
+
+## Anti-Patterns
+
+- ⊗ Explore codebase before Phase 1 questions
+- ⊗ Read framework files before first question
+- ⊗ Drip-feed questions one at a time when they can be batched
+- ⊗ Ask jargon-heavy questions to non-technical users
+- ⊗ Ask about things inferable from codebase (Phase 2+)
+- ⊗ Skip phases without asking
+- ⊗ Generate files without confirming content
+- ⊗ Present choices as plain text when structured tools exist

--- a/skills/install.sh
+++ b/skills/install.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env sh
+# Deft Directive — agent skill installer
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/visionik/deft/master/skills/install.sh | sh
+#
+# Clones the deft framework and wires up the deft skills so your AI agent
+# (Claude Code, OpenCode, Codex, Warp, etc.) discovers them automatically.
+#
+# Skills installed:
+#   deft-setup  — Conversational project setup (user prefs, project config, spec)
+#   deft-build  — Implement a spec following deft standards
+#
+# Options:
+#   --global          Install skills to your home directory (all projects)
+#   --no-clone        Skip cloning deft (use if deft/ already exists)
+#   --branch <name>   Clone a specific branch (default: master)
+#   --repo <url>      Clone from a different repo URL
+
+set -e
+
+REPO_URL="https://github.com/visionik/deft.git"
+BRANCH="master"
+DEFT_DIR="deft"
+SKILLS="deft-setup deft-build"
+GLOBAL=false
+CLONE=true
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --global)    GLOBAL=true ;;
+    --no-clone)  CLONE=false ;;
+    --branch)    shift; BRANCH="$1" ;;
+    --repo)      shift; REPO_URL="$1" ;;
+  esac
+  shift
+done
+
+# --- Clone deft if needed ---------------------------------------------------
+
+if [ "$CLONE" = true ]; then
+  if [ -d "$DEFT_DIR" ]; then
+    echo "deft/ already exists, skipping clone."
+  else
+    echo "Cloning deft framework (branch: $BRANCH)..."
+    git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$DEFT_DIR"
+  fi
+fi
+
+# Verify skills exist
+for skill in $SKILLS; do
+  if [ ! -f "$DEFT_DIR/skills/$skill/SKILL.md" ]; then
+    echo "Error: $DEFT_DIR/skills/$skill/SKILL.md not found." >&2
+    echo "Make sure deft is cloned at ./$DEFT_DIR" >&2
+    exit 1
+  fi
+done
+
+# --- Link skills for each platform ------------------------------------------
+
+link_skill() {
+  target_dir="$1"
+  source_path="$2"
+  skill_name="$3"
+
+  mkdir -p "$target_dir"
+  if [ -e "$target_dir/$skill_name" ] || [ -L "$target_dir/$skill_name" ]; then
+    echo "  $target_dir/$skill_name already exists, skipping."
+  else
+    ln -s "$source_path" "$target_dir/$skill_name"
+    echo "  Linked $target_dir/$skill_name"
+  fi
+}
+
+if [ "$GLOBAL" = true ]; then
+  echo "Installing skills globally..."
+
+  for skill in $SKILLS; do
+    SKILL_SRC="$(cd "$DEFT_DIR/skills" && pwd)/$skill"
+
+    # .agents/skills/ — Codex, OpenCode, Warp
+    link_skill "$HOME/.agents/skills" "$SKILL_SRC" "$skill"
+
+    # .claude/skills/ — Claude Code, OpenCode, Warp
+    link_skill "$HOME/.claude/skills" "$SKILL_SRC" "$skill"
+  done
+
+else
+  echo "Installing skills for this project..."
+
+  for skill in $SKILLS; do
+    REL_PATH="../../$DEFT_DIR/skills/$skill"
+
+    # .agents/skills/ — Codex, OpenCode, Warp
+    link_skill ".agents/skills" "$REL_PATH" "$skill"
+
+    # .claude/skills/ — Claude Code, OpenCode, Warp
+    link_skill ".claude/skills" "$REL_PATH" "$skill"
+  done
+fi
+
+# --- Done --------------------------------------------------------------------
+
+echo ""
+echo "Deft has been installed."
+echo ""
+echo "Open your favorite coding agent here and ask it to set up deft."
+echo ""
+echo "Supported: Claude Code, OpenCode, Codex, Warp"


### PR DESCRIPTION
### Problem
Deft is a framework for AI agents, but the onboarding flow (run bootstrap → run project → run spec) is a human-in-the-terminal CLI questionnaire. Users have to answer 25+ text prompts across three commands, then manually go back to their AI agent and say "now read the config files I just generated." The setup tool and the thing it's setting up live in two different contexts.

### Solution
A one-liner bash installer and two AgentSkills-compatible skills that move the entire onboarding and build flow inside the agent session.

```
cd my-project
curl -sSL https://raw.githubusercontent.com/visionik/deft/master/skills/install.sh | sh

Deft has been installed.

Open your favorite coding agent here and ask it to set up deft.
```

From there:
1. Agent gauges your technical level and adapts accordingly
2. Asks about preferences → writes USER.md
3. Infers tech stack from codebase, confirms → writes PROJECT.md
4. Interviews you about what to build → writes SPECIFICATION.md
5. Offers to start building immediately → hands off to `deft-build`
6. Implements the spec phase by phase with TDD and quality gates

One conversation. No context switching.