### PR TITLE
docs(changelog): add Unity platform standards entry to v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Archive Merge Protocol**: Spec delta merge into main spec + CHANGELOG entry on archive (#20)
 - **Session Commands**: `/deft:continue` and `/deft:checkpoint` for session management (#16, #20)
 - **Glossary**: Added "Spec delta" term definition (#19)
+- **Unity Platform Standards**: `platforms/unity.md` — Unity 6+ development standards covering project structure, MonoBehaviours, ScriptableObjects, performance, Addressables, testing, and source control (#27)
 
 ### Changed
 - **Strategy Renames**: `default.md` → `interview.md`, `brownfield.md` → `map.md` (#16)


### PR DESCRIPTION
Adds the missing bullet point for `platforms/unity.md` (#27) to the v0.6.0 Added section in CHANGELOG.md.

This entry was drafted locally during the `feature-vbrief-schema` branch but was never committed before cleanup.