### PR TITLE
feat(installer): agent auto-alignment via skill pointers and change lifecycle rule

### DIFF
--- a/.agents/skills/deft-build/SKILL.md
+++ b/.agents/skills/deft-build/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: deft-build
+description: >-
+  Build a project from a SPECIFICATION.md following Deft framework standards.
+  Use after deft-setup has generated the spec, or when the user has a
+  SPECIFICATION.md ready to implement. Handles scaffolding, implementation,
+  testing, and quality checks phase by phase.
+---
+
+Read and follow: skills/deft-build/SKILL.md

--- a/.agents/skills/deft-setup/SKILL.md
+++ b/.agents/skills/deft-setup/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: deft-setup
+description: >-
+  Set up a new project with Deft framework standards. Use when the user wants
+  to bootstrap user preferences, configure a project, or generate a project
+  specification. Walks through setup conversationally — no separate CLI needed.
+---
+
+Read and follow: skills/deft-setup/SKILL.md

--- a/.agents/skills/deft/SKILL.md
+++ b/.agents/skills/deft/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: deft
+description: Apply deft framework standards for AI-assisted development. Use when starting projects, writing code, running tests, making commits, or when the user references deft, project standards, or coding guidelines.
+---
+
+Read and follow: SKILL.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,4 +34,3 @@ When all config exists: read the guidelines, your USER.md preferences, and PROJE
 Note: paths here are root-relative — this repo IS the deft directory.
 Install-generated AGENTS.md uses deft/-prefixed paths.
 
-Skills: SKILL.md, skills/deft-setup/SKILL.md, skills/deft-build/SKILL.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AGENTS.md** (in-repo): Removed redundant Skills line — `.agents/skills/` handles discovery (#94)
 - **agentsMDEntry**: Removed Skills line from install-generated AGENTS.md — `.agents/skills/` handles discovery, resolving the TODO from #75 (#94)
 
-## [0.7.1]
+## [0.7.1] - 2026-03-20
 
 ### Fixed
 - **AGENTS.md Onboarding**: Install-generated `AGENTS.md` now contains self-contained bootstrap logic — first-session phase detection (USER.md → Phase 1, PROJECT.md → Phase 2, SPECIFICATION.md → Phase 3), returning-session guidance, and available commands reference (#54, closes #85)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.1] - 2026-03-20
+### Added
+- **Agent Skill Auto-Discovery**: Added `.agents/skills/deft/`, `deft-setup/`, `deft-build/` thin pointer files to the repo — Warp and other agents now auto-discover deft skills on startup without user prompting (#94)
+- **WriteAgentsSkills**: Installer now creates `.agents/skills/` in user project root during install so agents auto-discover deft skills immediately (#94)
+- **Prescriptive Change Lifecycle Rule**: Added `! Before implementing any planned change that touches 3+ files or has an accepted plan artifact, propose /deft:change <name> and wait for confirmation` to `main.md` Decision Making section (#94)
+
+### Changed
+- **PrintNextSteps**: Installer output updated to reflect auto-discovery — no longer tells users to manually say 'read AGENTS.md and follow it' (#94)
+- **AGENTS.md** (in-repo): Removed redundant Skills line — `.agents/skills/` handles discovery (#94)
+- **agentsMDEntry**: Removed Skills line from install-generated AGENTS.md — `.agents/skills/` handles discovery, resolving the TODO from #75 (#94)
+
+## [0.7.1]
 
 ### Fixed
 - **AGENTS.md Onboarding**: Install-generated `AGENTS.md` now contains self-contained bootstrap logic — first-session phase detection (USER.md → Phase 1, PROJECT.md → Phase 2, SPECIFICATION.md → Phase 3), returning-session guidance, and available commands reference (#54, closes #85)

--- a/cmd/deft-install/main.go
+++ b/cmd/deft-install/main.go
@@ -133,6 +133,11 @@ func install(debug bool, branch string) int {
 		return 1
 	}
 
+	if err := WriteAgentsSkills(w, result.ProjectDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
 	configDir, err := CreateUserConfigDir(w)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/deft-install/main.go
+++ b/cmd/deft-install/main.go
@@ -133,7 +133,8 @@ func install(debug bool, branch string) int {
 		return 1
 	}
 
-	if err := WriteAgentsSkills(w, result.ProjectDir); err != nil {
+	skillsCreated, err := WriteAgentsSkills(w, result.ProjectDir)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
 	}
@@ -144,7 +145,7 @@ func install(debug bool, branch string) int {
 		return 1
 	}
 
-	PrintNextSteps(w, result, configDir)
+	PrintNextSteps(w, result, configDir, skillsCreated)
 	return 0
 }
 

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -505,6 +505,9 @@ func TestWriteAgentsMD_CreateNew(t *testing.T) {
 			t.Errorf("AGENTS.md missing section %q", section)
 		}
 	}
+	if strings.Contains(string(data), "Skills: deft/SKILL.md") {
+		t.Error("AGENTS.md should not contain Skills line — .agents/skills/ handles discovery")
+	}
 }
 
 func TestWriteAgentsMD_AppendExisting(t *testing.T) {
@@ -570,6 +573,50 @@ func TestUserConfigDir_Default(t *testing.T) {
 	}
 }
 
+func TestWriteAgentsSkills_CreateNew(t *testing.T) {
+	tmp := t.TempDir()
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+
+	if err := WriteAgentsSkills(w, tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, skill := range []string{"deft", "deft-setup", "deft-build"} {
+		path := filepath.Join(tmp, ".agents", "skills", skill, "SKILL.md")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("missing skill file for %s: %v", skill, err)
+		}
+		if !strings.Contains(string(data), "deft/") {
+			t.Errorf("%s/SKILL.md missing deft/-prefixed path, got:\n%s", skill, data)
+		}
+		if !strings.Contains(string(data), "name: "+skill) {
+			t.Errorf("%s/SKILL.md missing name frontmatter", skill)
+		}
+	}
+}
+
+func TestWriteAgentsSkills_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
+
+	// Write twice.
+	WriteAgentsSkills(w, tmp)
+
+	// Overwrite the deft SKILL.md with sentinel content.
+	sentinel := []byte("sentinel content")
+	deftPath := filepath.Join(tmp, ".agents", "skills", "deft", "SKILL.md")
+	os.WriteFile(deftPath, sentinel, 0o644)
+
+	// Second call should skip.
+	WriteAgentsSkills(w, tmp)
+
+	data, _ := os.ReadFile(deftPath)
+	if string(data) != string(sentinel) {
+		t.Error("expected second WriteAgentsSkills call to be idempotent (no overwrite)")
+	}
+}
+
 func TestPrintNextSteps(t *testing.T) {
 	var buf bytes.Buffer
 	w := NewWizard(strings.NewReader(""), &buf, false)
@@ -587,9 +634,8 @@ func TestPrintNextSteps(t *testing.T) {
 		result.DeftDir,
 		"AGENTS.md",
 		"User config",
-		"read AGENTS.md and follow it",
+		"auto-discovered",
 		"USER.md and PROJECT.md",
-		"do not read AGENTS.md automatically",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q", want)

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -611,9 +611,14 @@ func TestWriteAgentsSkills_Idempotent(t *testing.T) {
 	os.WriteFile(deftPath, sentinel, 0o644)
 
 	// Second call should skip (all three files exist).
-	_, _ = WriteAgentsSkills(w, tmp)
+	if _, err := WriteAgentsSkills(w, tmp); err != nil {
+		t.Fatalf("second WriteAgentsSkills call failed unexpectedly: %v", err)
+	}
 
-	data, _ := os.ReadFile(deftPath)
+	data, err := os.ReadFile(deftPath)
+	if err != nil {
+		t.Fatalf("could not read sentinel file: %v", err)
+	}
 	if string(data) != string(sentinel) {
 		t.Error("expected second WriteAgentsSkills call to be idempotent (no overwrite)")
 	}
@@ -638,9 +643,30 @@ func TestPrintNextSteps(t *testing.T) {
 		"User config",
 		"Use AGENTS.md",
 		"USER.md and PROJECT.md",
+		"created",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q", want)
 		}
+	}
+}
+
+func TestPrintNextSteps_SkillsAlreadyPresent(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWizard(strings.NewReader(""), &buf, false)
+	result := &WizardResult{
+		ProjectName: "myproj",
+		ProjectDir:  `E:\Repos\myproj`,
+		DeftDir:     `E:\Repos\myproj\deft`,
+	}
+
+	PrintNextSteps(w, result, `C:\Users\me\AppData\Roaming\deft`, false)
+
+	out := buf.String()
+	if !strings.Contains(out, "already present") {
+		t.Error("output missing \"already present\" for skillsCreated=false")
+	}
+	if strings.Contains(out, "created") {
+		t.Error("output should not contain \"created\" for skillsCreated=false")
 	}
 }

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -577,7 +577,7 @@ func TestWriteAgentsSkills_CreateNew(t *testing.T) {
 	tmp := t.TempDir()
 	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
 
-	if err := WriteAgentsSkills(w, tmp); err != nil {
+	if _, err := WriteAgentsSkills(w, tmp); err != nil {
 		t.Fatal(err)
 	}
 
@@ -600,16 +600,18 @@ func TestWriteAgentsSkills_Idempotent(t *testing.T) {
 	tmp := t.TempDir()
 	w := NewWizard(strings.NewReader(""), &bytes.Buffer{}, false)
 
-	// Write twice.
-	WriteAgentsSkills(w, tmp)
+	// Write once (setup).
+	if _, err := WriteAgentsSkills(w, tmp); err != nil {
+		t.Fatal("setup WriteAgentsSkills failed:", err)
+	}
 
 	// Overwrite the deft SKILL.md with sentinel content.
 	sentinel := []byte("sentinel content")
 	deftPath := filepath.Join(tmp, ".agents", "skills", "deft", "SKILL.md")
 	os.WriteFile(deftPath, sentinel, 0o644)
 
-	// Second call should skip.
-	WriteAgentsSkills(w, tmp)
+	// Second call should skip (all three files exist).
+	_, _ = WriteAgentsSkills(w, tmp)
 
 	data, _ := os.ReadFile(deftPath)
 	if string(data) != string(sentinel) {
@@ -626,7 +628,7 @@ func TestPrintNextSteps(t *testing.T) {
 		DeftDir:     `E:\Repos\myproj\deft`,
 	}
 
-	PrintNextSteps(w, result, `C:\Users\me\AppData\Roaming\deft`)
+	PrintNextSteps(w, result, `C:\Users\me\AppData\Roaming\deft`, true)
 
 	out := buf.String()
 	for _, want := range []string{

--- a/cmd/deft-install/main_test.go
+++ b/cmd/deft-install/main_test.go
@@ -634,7 +634,7 @@ func TestPrintNextSteps(t *testing.T) {
 		result.DeftDir,
 		"AGENTS.md",
 		"User config",
-		"auto-discovered",
+		"Use AGENTS.md",
 		"USER.md and PROJECT.md",
 	} {
 		if !strings.Contains(out, want) {

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -183,13 +183,21 @@ func WriteAgentsMD(w *Wizard, projectDir string) error {
 // project root so AI agents auto-discover deft skills without user prompting.
 // Each skill gets its own subdirectory with a thin SKILL.md pointer that
 // redirects agents to the canonical skill files inside deft/.
-// Idempotent — skips if .agents/skills/deft/SKILL.md already exists.
-func WriteAgentsSkills(w *Wizard, projectDir string) error {
-	deftSkillPath := filepath.Join(projectDir, ".agents", "skills", "deft", "SKILL.md")
-
-	if _, err := os.Stat(deftSkillPath); err == nil {
-		w.printf(".agents/skills/ already exists — skipping.\n")
-		return nil
+// Idempotent — skips only when all three skill files are present.
+// Returns true if files were created, false if skipped.
+func WriteAgentsSkills(w *Wizard, projectDir string) (bool, error) {
+	// Check all three skill files before deciding to skip.
+	allExist := true
+	for _, skill := range []string{"deft", "deft-setup", "deft-build"} {
+		p := filepath.Join(projectDir, ".agents", "skills", skill, "SKILL.md")
+		if _, err := os.Stat(p); err != nil {
+			allExist = false
+			break
+		}
+	}
+	if allExist {
+		w.printf(".agents/skills/ already present — skipping.\n")
+		return false, nil
 	}
 
 	skills := []struct {
@@ -204,16 +212,16 @@ func WriteAgentsSkills(w *Wizard, projectDir string) error {
 	for _, skill := range skills {
 		dir := filepath.Join(projectDir, ".agents", "skills", skill.dir)
 		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return fmt.Errorf("could not create %s: %w", dir, err)
+			return false, fmt.Errorf("could not create %s: %w", dir, err)
 		}
 		path := filepath.Join(dir, "SKILL.md")
 		if err := os.WriteFile(path, []byte(skill.content), 0o644); err != nil {
-			return fmt.Errorf("could not write %s: %w", path, err)
+			return false, fmt.Errorf("could not write %s: %w", path, err)
 		}
 	}
 
 	w.printf(".agents/skills/ created — deft skills will be auto-discovered.\n")
-	return nil
+	return true, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -258,11 +266,15 @@ func CreateUserConfigDir(w *Wizard) (string, error) {
 // ---------------------------------------------------------------------------
 
 // PrintNextSteps displays the success banner and post-install instructions.
-func PrintNextSteps(w *Wizard, result *WizardResult, configDir string) {
+func PrintNextSteps(w *Wizard, result *WizardResult, configDir string, skillsCreated bool) {
+	skillsStatus := "already present"
+	if skillsCreated {
+		skillsStatus = "created"
+	}
 	w.printf("\n✓ Deft installed successfully!\n\n")
 	w.printf("  Location     : %s%c\n", result.DeftDir, os.PathSeparator)
 	w.printf("  AGENTS.md    : updated\n")
-	w.printf("  Skills       : .agents/skills/ created (auto-discovered by AI agents)\n")
+	w.printf("  Skills       : .agents/skills/ %s (auto-discovered by AI agents)\n", skillsStatus)
 	w.printf("  User config  : %s%c\n", configDir, os.PathSeparator)
 	w.printf("\nNext steps:\n")
 	w.printf("  1. Open your AI coding assistant in %s%c\n", result.ProjectDir, os.PathSeparator)

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -191,6 +192,9 @@ func WriteAgentsSkills(w *Wizard, projectDir string) (bool, error) {
 	for _, skill := range []string{"deft", "deft-setup", "deft-build"} {
 		p := filepath.Join(projectDir, ".agents", "skills", skill, "SKILL.md")
 		if _, err := os.Stat(p); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return false, fmt.Errorf("could not check %s: %w", p, err)
+			}
 			allExist = false
 			break
 		}
@@ -215,6 +219,9 @@ func WriteAgentsSkills(w *Wizard, projectDir string) (bool, error) {
 			return false, fmt.Errorf("could not create %s: %w", dir, err)
 		}
 		path := filepath.Join(dir, "SKILL.md")
+		if _, err := os.Stat(path); err == nil {
+			continue // already present — leave as-is
+		}
 		if err := os.WriteFile(path, []byte(skill.content), 0o644); err != nil {
 			return false, fmt.Errorf("could not write %s: %w", path, err)
 		}

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -14,7 +14,6 @@ const (
 	// agentsMDEntry is written into the project's AGENTS.md during install.
 	// It must contain agentsMDSentinel ("deft/main.md") for idempotency —
 	// WriteAgentsMD checks for that string before appending.
-	// TODO: remove the Skills line when #75 (skill auto-discovery) ships.
 	agentsMDEntry = `# Deft — AI Development Framework
 
 Deft is installed in deft/. Full guidelines: deft/main.md
@@ -46,11 +45,41 @@ When all config exists: read the guidelines, your USER.md preferences, and PROJE
 - /deft:run:map              — Map an existing codebase
 - deft/run bootstrap         — CLI setup (terminal users)
 - deft/run spec              — CLI spec generation
-
-Skills: deft/SKILL.md, deft/skills/deft-setup/SKILL.md, deft/skills/deft-build/SKILL.md
 `
 	// Sentinel used to detect an existing deft entry in AGENTS.md.
 	agentsMDSentinel = "deft/main.md"
+
+	// agentsSkillDeft is the thin pointer content for .agents/skills/deft/SKILL.md.
+	agentsSkillDeft = `---
+name: deft
+description: Apply deft framework standards for AI-assisted development. Use when starting projects, writing code, running tests, making commits, or when the user references deft, project standards, or coding guidelines.
+---
+
+Read and follow: deft/SKILL.md
+`
+	// agentsSkillDeftSetup is the thin pointer content for .agents/skills/deft-setup/SKILL.md.
+	agentsSkillDeftSetup = `---
+name: deft-setup
+description: >-
+  Set up a new project with Deft framework standards. Use when the user wants
+  to bootstrap user preferences, configure a project, or generate a project
+  specification. Walks through setup conversationally — no separate CLI needed.
+---
+
+Read and follow: deft/skills/deft-setup/SKILL.md
+`
+	// agentsSkillDeftBuild is the thin pointer content for .agents/skills/deft-build/SKILL.md.
+	agentsSkillDeftBuild = `---
+name: deft-build
+description: >-
+  Build a project from a SPECIFICATION.md following Deft framework standards.
+  Use after deft-setup has generated the spec, or when the user has a
+  SPECIFICATION.md ready to implement. Handles scaffolding, implementation,
+  testing, and quality checks phase by phase.
+---
+
+Read and follow: deft/skills/deft-build/SKILL.md
+`
 )
 
 // ---------------------------------------------------------------------------
@@ -147,7 +176,48 @@ func WriteAgentsMD(w *Wizard, projectDir string) error {
 }
 
 // ---------------------------------------------------------------------------
-// 4.3 Create USER.md config directory
+// 4.3 Write .agents/skills/ thin pointer files
+// ---------------------------------------------------------------------------
+
+// WriteAgentsSkills creates the .agents/skills/ discovery structure in the
+// project root so AI agents auto-discover deft skills without user prompting.
+// Each skill gets its own subdirectory with a thin SKILL.md pointer that
+// redirects agents to the canonical skill files inside deft/.
+// Idempotent — skips if .agents/skills/deft/SKILL.md already exists.
+func WriteAgentsSkills(w *Wizard, projectDir string) error {
+	deftSkillPath := filepath.Join(projectDir, ".agents", "skills", "deft", "SKILL.md")
+
+	if _, err := os.Stat(deftSkillPath); err == nil {
+		w.printf(".agents/skills/ already exists — skipping.\n")
+		return nil
+	}
+
+	skills := []struct {
+		dir     string
+		content string
+	}{
+		{"deft", agentsSkillDeft},
+		{"deft-setup", agentsSkillDeftSetup},
+		{"deft-build", agentsSkillDeftBuild},
+	}
+
+	for _, skill := range skills {
+		dir := filepath.Join(projectDir, ".agents", "skills", skill.dir)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("could not create %s: %w", dir, err)
+		}
+		path := filepath.Join(dir, "SKILL.md")
+		if err := os.WriteFile(path, []byte(skill.content), 0o644); err != nil {
+			return fmt.Errorf("could not write %s: %w", path, err)
+		}
+	}
+
+	w.printf(".agents/skills/ created — deft skills will be auto-discovered.\n")
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// 4.4 Create USER.md config directory
 // ---------------------------------------------------------------------------
 
 // UserConfigDir returns the platform-appropriate deft config directory.
@@ -184,19 +254,19 @@ func CreateUserConfigDir(w *Wizard) (string, error) {
 }
 
 // ---------------------------------------------------------------------------
-// 4.4 Print next steps
+// 4.5 Print next steps
 // ---------------------------------------------------------------------------
 
 // PrintNextSteps displays the success banner and post-install instructions.
 func PrintNextSteps(w *Wizard, result *WizardResult, configDir string) {
 	w.printf("\n✓ Deft installed successfully!\n\n")
-	w.printf("  Location  : %s%c\n", result.DeftDir, os.PathSeparator)
-	w.printf("  AGENTS.md : updated\n")
-	w.printf("  User config: %s%c\n", configDir, os.PathSeparator)
+	w.printf("  Location     : %s%c\n", result.DeftDir, os.PathSeparator)
+	w.printf("  AGENTS.md    : updated\n")
+	w.printf("  Skills       : .agents/skills/ created (auto-discovered by AI agents)\n")
+	w.printf("  User config  : %s%c\n", configDir, os.PathSeparator)
 	w.printf("\nNext steps:\n")
 	w.printf("  1. Open your AI coding assistant in %s%c\n", result.ProjectDir, os.PathSeparator)
-	w.printf("  2. Tell your agent: \"read AGENTS.md and follow it\" to start the Deft setup\n")
+	w.printf("  2. Deft skills are auto-discovered — your agent will guide setup automatically\n")
 	w.printf("  3. On first session, the agent will guide you through creating USER.md and PROJECT.md\n")
-	w.printf("     Note: agents do not read AGENTS.md automatically — auto-discovery is planned for a future release\n")
 	w.printf("\n")
 }

--- a/cmd/deft-install/setup.go
+++ b/cmd/deft-install/setup.go
@@ -266,7 +266,8 @@ func PrintNextSteps(w *Wizard, result *WizardResult, configDir string) {
 	w.printf("  User config  : %s%c\n", configDir, os.PathSeparator)
 	w.printf("\nNext steps:\n")
 	w.printf("  1. Open your AI coding assistant in %s%c\n", result.ProjectDir, os.PathSeparator)
-	w.printf("  2. Deft skills are auto-discovered — your agent will guide setup automatically\n")
+	w.printf("  2. Deft skill auto-discovery is partially implemented — if your agent doesn't\n")
+	w.printf("     start setup automatically, tell it: \"Use AGENTS.md\"\n")
 	w.printf("  3. On first session, the agent will guide you through creating USER.md and PROJECT.md\n")
 	w.printf("\n")
 }

--- a/cmd/deft-install/wizard.go
+++ b/cmd/deft-install/wizard.go
@@ -429,16 +429,16 @@ func isSystemFolder(name string) bool {
 	system := map[string]bool{
 		"$recycle.bin":              true,
 		"system volume information": true,
-		"windows":                  true,
-		"program files":            true,
-		"program files (x86)":      true,
-		"programdata":              true,
-		"recovery":                 true,
-		"perflogs":                 true,
-		"config.msi":               true,
-		"msocache":                 true,
-		"boot":                     true,
-		"documents and settings":   true,
+		"windows":                   true,
+		"program files":             true,
+		"program files (x86)":       true,
+		"programdata":               true,
+		"recovery":                  true,
+		"perflogs":                  true,
+		"config.msi":                true,
+		"msocache":                  true,
+		"boot":                      true,
+		"documents and settings":    true,
 	}
 	return system[strings.ToLower(name)]
 }

--- a/history/analysis-2026-03-22-issue-chain-68-94.md
+++ b/history/analysis-2026-03-22-issue-chain-68-94.md
@@ -1,0 +1,57 @@
+# Analysis: Agent Non-Compliance Failure Chain (#68 → #94)
+
+**Date:** 2026-03-22
+**Trigger:** User report — new packages added without tests, CI average below 80%, agent incrementally patching test files one at a time instead of front-loading TDD.
+**Related issues:** #68, #72, #75, #84, #94
+
+## User Report Summary
+
+A deft user (John) reported that after updating DEFT and explicitly asking the agent to use it:
+
+- New packages were committed without tests, dragging CI coverage below 80%
+- The agent attempted to fix coverage incrementally ("just 0.01% to CI!") rather than writing tests alongside code
+- When pressed, the agent admitted partial compliance:
+  - **Followed:** TDD (partially), `task check` gate, conventional commits, hyphenated filenames, ≥85% coverage target (but fell short at 84.8%)
+  - **Skipped:** vBRIEF plan artifacts, `history/` plan archiving, `/deft:change` lifecycle
+- The agent had to be "drilled" to confirm it was actually using DEFT — gave evasive answers before admitting the gaps
+
+A second user (Shinran7) independently reported the same pattern in #68: zero of seven test paradigms followed across multiple commits, agent blamed "rapid change cadence."
+
+## Issue Mapping
+
+### #68 — Warp not always enforcing Deft testing protocols (direct match)
+
+Both users experienced the same failure: testing treated as a cleanup step, not a gate. The agent follows surface conventions (naming, commit format) but skips structural ones (TDD, coverage gates). When confronted, the agent rationalizes rather than acknowledging the gap.
+
+### #94 — Agent auto-alignment on startup (root cause)
+
+The conversation proves both gaps described in #94:
+
+- **Gap 1 (no auto-discovery):** John had to manually tell the agent to use DEFT. Without `.agents/skills/` discovery, the agent doesn't load deft on startup.
+- **Gap 2 (no prescriptive change lifecycle):** Even after loading DEFT, the agent skipped `/deft:change` and went straight to code. `main.md` describes the workflow but doesn't mandate it, so the agent optimized it away.
+
+### #72 — Trouble creating proper vBRIEF files
+
+The agent explicitly admitted it didn't create vBRIEF plan artifacts. A different user (visionik) independently reported invalid vBRIEF output in #72. Two users, same failure: DEFT's plan artifact spec is either not being read, not being followed, or not clear enough for agents to execute.
+
+### #75 — Skill auto-discovery
+
+The infrastructure layer beneath #94. Without `.agents/skills/` discovery directories, agents only find DEFT via manual instruction. Necessary but not sufficient — John told the agent and it still didn't fully comply.
+
+### #84 — Deft as teacher, not just enforcer
+
+The agent's response illustrates Gap 2 of #84: it listed conventions as checkbox compliance but didn't internalize *why* TDD is front-loaded or *why* vBRIEF exists. It cargo-culted surface conventions while skipping the structural ones that matter most.
+
+## Failure Chain
+
+These are one failure chain, not five separate bugs:
+
+1. Agent doesn't auto-load DEFT → **#75, #94 Gap 1**
+2. Even when loaded, no mandatory workflow gate → **#94 Gap 2**
+3. Agent follows surface conventions, skips structural ones (TDD, vBRIEF) → **#68, #72**
+4. Agent doesn't understand *why* rules exist, triages them away under pressure → **#84**
+5. Result: incremental test-patching, CI chasing, users drilling the agent to prove compliance
+
+## Recommendation
+
+**#94 is the highest-leverage fix.** Thin skill pointers solve discovery (Gap 1), and the prescriptive change lifecycle rule forces `/deft:change` before implementation (Gap 2) — which naturally front-loads test planning and vBRIEF creation instead of letting the agent skip them.

--- a/history/archive/2026-03-20-agent-auto-alignment/design.md
+++ b/history/archive/2026-03-20-agent-auto-alignment/design.md
@@ -1,0 +1,101 @@
+# Technical Design: agent-auto-alignment
+
+## Approach
+
+### Thin pointer file content
+
+Each `.agents/skills/<name>/SKILL.md` has:
+1. YAML frontmatter with `name` and `description` matching the real skill (required for Warp discovery)
+2. A single redirect instruction in the body
+
+**Deft repo versions (root-relative paths):**
+
+`.agents/skills/deft/SKILL.md`:
+```markdown
+---
+name: deft
+description: Apply deft framework standards for AI-assisted development. Use when starting projects, writing code, running tests, making commits, or when the user references deft, project standards, or coding guidelines.
+---
+
+Read and follow: SKILL.md
+```
+
+`.agents/skills/deft-setup/SKILL.md`:
+```markdown
+---
+name: deft-setup
+description: >-
+  Set up a new project with Deft framework standards. Use when the user wants
+  to bootstrap user preferences, configure a project, or generate a project
+  specification. Walks through setup conversationally — no separate CLI needed.
+---
+
+Read and follow: skills/deft-setup/SKILL.md
+```
+
+`.agents/skills/deft-build/SKILL.md`:
+```markdown
+---
+name: deft-build
+description: >-
+  Build a project from a SPECIFICATION.md following Deft framework standards.
+  Use after deft-setup has generated the spec, or when the user has a
+  SPECIFICATION.md ready to implement. Handles scaffolding, implementation,
+  testing, and quality checks phase by phase.
+---
+
+Read and follow: skills/deft-build/SKILL.md
+```
+
+**Installer-generated versions (deft/-prefixed paths, for user projects):**
+Same structure but paths become `deft/SKILL.md`, `deft/skills/deft-setup/SKILL.md`, `deft/skills/deft-build/SKILL.md`.
+
+### `WriteAgentsSkills` function in `setup.go`
+
+```go
+func WriteAgentsSkills(w *Wizard, projectDir string) error
+```
+
+- Creates `.agents/skills/deft/`, `deft-setup/`, `deft-build/` under projectDir
+- Writes thin pointer SKILL.md to each with `deft/`-prefixed paths
+- Idempotent: if `.agents/skills/deft/SKILL.md` already exists, skips with a log message
+- Returns error only on filesystem failures
+
+### `agentsMDEntry` update
+
+Remove the Skills line and its Go comment. Verify "deft/main.md" still appears in content (sentinel check).
+
+New content ends with:
+```
+...
+- deft/run bootstrap         — CLI setup (terminal users)
+- deft/run spec              — CLI spec generation
+```
+(No Skills line.)
+
+### `PrintNextSteps` update
+
+Replace step 2 from "Tell your agent: read AGENTS.md and follow it" with something like:
+"Open your AI coding assistant — deft skills are auto-discovered and will guide setup automatically"
+
+And remove the note about agents not reading AGENTS.md automatically — that's no longer true once `.agents/skills/` is in place.
+
+### `main.md` rule placement
+
+Add to the Decision Making block in Agent Behavior:
+```
+! Before implementing any planned change that touches 3+ files or has an accepted plan artifact, propose /deft:change <name> and wait for confirmation
+```
+
+## Alternatives Considered
+
+**Symlinks instead of thin pointers** — rejected. Requires Developer Mode or elevation on Windows. Thin pointers achieve the same result with zero platform dependencies.
+
+**File copies instead of thin pointers** — rejected. Copies rot on deft updates. Thin pointers always redirect to current content.
+
+**Single `.agents/skills/deft/SKILL.md` pointing to all three skills** — rejected. Warp skill discovery is per-subdirectory; each skill needs its own subdirectory to be independently invokable.
+
+## Dependencies
+
+- SKILL.md frontmatter `description` values must be sourced from the actual skill files
+- `agentsMDSentinel = "deft/main.md"` must still appear in `agentsMDEntry` after removing Skills line (it does — it appears in "Full guidelines: deft/main.md")

--- a/history/archive/2026-03-20-agent-auto-alignment/proposal.md
+++ b/history/archive/2026-03-20-agent-auto-alignment/proposal.md
@@ -1,0 +1,46 @@
+# Change Proposal: agent-auto-alignment
+
+## Problem
+
+Two complementary gaps mean agents never auto-align with deft on startup and skip the correct workflow even when they do:
+
+1. **No auto-discovery** — agents must be manually told to read AGENTS.md every new session. Any improvement to `main.md`, strategy files, or teaching behavior (#84) is invisible until the agent happens to load deft. This is the primary adoption blocker post #54.
+
+2. **No prescriptive change lifecycle rule** — even when an agent fully loads deft, it skips `/deft:change` before implementing planned work. `main.md` lists the commands but doesn't mandate their use — it's descriptive, not prescriptive. Agents go straight to code.
+
+These are inseparable: gap 1 without gap 2 means the agent loads deft but still skips workflow steps. Gap 2 without gap 1 means the rule never fires.
+
+## Change
+
+- Create `.agents/skills/deft/`, `.agents/skills/deft-setup/`, `.agents/skills/deft-build/` in the deft repo with thin pointer `SKILL.md` files — committed static files, never change on deft updates, redirect agents to canonical skill files (root-relative paths)
+- Update `deft-install` to write the same `.agents/skills/` structure in user project root during install (`deft/`-prefixed paths), via a new `WriteAgentsSkills` function
+- Remove the `Skills:` line from `agentsMDEntry` (`.agents/skills/` now handles discovery — this was the TODO pending #75/#94)
+- Add prescriptive change lifecycle rule to `main.md`: before implementing any planned change touching 3+ files or with an accepted plan artifact, propose `/deft:change <name>` and wait for confirmation
+- Remove Skills line from in-repo `AGENTS.md` (redundant once `.agents/skills/` exists)
+- Update `PrintNextSteps` to reflect auto-discovery (no longer needs explicit "tell your agent to read AGENTS.md")
+- Add `TestWriteAgentsSkills_CreateNew` and `TestWriteAgentsSkills_Idempotent` tests
+
+## Scope
+
+**In:**
+- `.agents/skills/` directory in deft repo (3 thin pointer files)
+- `cmd/deft-install/setup.go` — `WriteAgentsSkills` + remove Skills line from `agentsMDEntry` + update `PrintNextSteps`
+- `cmd/deft-install/main_test.go` — 2 new tests
+- `main.md` — prescriptive change lifecycle rule
+- `AGENTS.md` (in-repo) — remove Skills line
+
+**Out:**
+- Global `~/.agents/skills/` install — needs fixed global deft path (Phase 4 / #56 / #11)
+- Other skill directories (`.warp/skills/`, `.claude/skills/`, etc.) — `.agents/skills/` is universal; Warp scans all
+- `agentsMDSentinel` or `WriteAgentsMD` idempotency logic — unaffected
+
+## Impact
+
+- Users who install via the new binary will get `.agents/skills/` created automatically
+- Existing installs are unaffected (no `.agents/skills/` until re-install)
+- Developers working in the deft repo get auto-alignment immediately on next Warp session after this merges
+
+## Risks
+
+- Thin pointer content must have correct YAML frontmatter (name + description) matching the real SKILL.md so Warp discovers it with the right metadata
+- The `Skills:` line removal from `agentsMDEntry` changes the sentinel check indirectly — must verify `agentsMDSentinel` ("deft/main.md") still appears in the new content

--- a/history/archive/2026-03-20-agent-auto-alignment/tasks.vbrief.json
+++ b/history/archive/2026-03-20-agent-auto-alignment/tasks.vbrief.json
@@ -1,0 +1,139 @@
+﻿{
+    "vBRIEFInfo":  {
+                       "version":  "0.5"
+                   },
+    "plan":  {
+                 "title":  "agent-auto-alignment",
+                 "status":  "completed",
+                 "items":  [
+                               {
+                                   "id":  "t1",
+                                   "title":  "Create .agents/skills/ thin pointer files in deft repo",
+                                   "status":  "completed",
+                                   "narrative":  {
+                                                     "Action":  "Create three thin pointer SKILL.md files committed to the deft repo root for developer auto-alignment",
+                                                     "AcceptanceCriteria":  [
+                                                                                ".agents/skills/deft/SKILL.md exists with correct frontmatter (name: deft, description matching SKILL.md) and body: \u0027Read and follow: SKILL.md\u0027",
+                                                                                ".agents/skills/deft-setup/SKILL.md exists with correct frontmatter and body: \u0027Read and follow: skills/deft-setup/SKILL.md\u0027",
+                                                                                ".agents/skills/deft-build/SKILL.md exists with correct frontmatter and body: \u0027Read and follow: skills/deft-build/SKILL.md\u0027",
+                                                                                "Paths are root-relative (no deft/ prefix)"
+                                                                            ]
+                                                 }
+                               },
+                               {
+                                   "id":  "t2",
+                                   "title":  "Add WriteAgentsSkills to setup.go + remove Skills line from agentsMDEntry",
+                                   "status":  "completed",
+                                   "narrative":  {
+                                                     "Action":  "New WriteAgentsSkills function creates .agents/skills/ structure in user project root during install. Also remove Skills line and TODO comment from agentsMDEntry.",
+                                                     "AcceptanceCriteria":  [
+                                                                                "WriteAgentsSkills creates .agents/skills/deft/, deft-setup/, deft-build/ subdirs with SKILL.md thin pointers using deft/-prefixed paths",
+                                                                                "Idempotent: second call skips if .agents/skills/deft/SKILL.md already exists",
+                                                                                "WriteAgentsSkills is called from install sequence after WriteAgentsMD",
+                                                                                "agentsMDEntry no longer contains Skills line or TODO comment",
+                                                                                "agentsMDSentinel string (\u0027deft/main.md\u0027) still present in agentsMDEntry content"
+                                                                            ]
+                                                 }
+                               },
+                               {
+                                   "id":  "t3",
+                                   "title":  "Update PrintNextSteps in setup.go",
+                                   "status":  "completed",
+                                   "narrative":  {
+                                                     "Action":  "Replace explicit \u0027tell your agent to read AGENTS.md\u0027 instruction with auto-discovery messaging",
+                                                     "AcceptanceCriteria":  [
+                                                                                "Step 2 no longer says \u0027Tell your agent: read AGENTS.md and follow it\u0027",
+                                                                                "Step 2 reflects that deft skills are auto-discovered",
+                                                                                "Note about agents not reading AGENTS.md automatically is removed"
+                                                                            ]
+                                                 }
+                               },
+                               {
+                                   "id":  "t4",
+                                   "title":  "Add TestWriteAgentsSkills tests to main_test.go",
+                                   "status":  "completed",
+                                   "narrative":  {
+                                                     "Action":  "Add TestWriteAgentsSkills_CreateNew and TestWriteAgentsSkills_Idempotent",
+                                                     "AcceptanceCriteria":  [
+                                                                                "TestWriteAgentsSkills_CreateNew verifies all three subdirs exist with SKILL.md files containing deft/-prefixed paths",
+                                                                                "TestWriteAgentsSkills_Idempotent verifies second call does not overwrite existing files",
+                                                                                "Update TestPrintNextSteps assertions to match new step 2 output",
+                                                                                "Update TestWriteAgentsMD_CreateNew to confirm Skills line no longer present in agentsMDEntry"
+                                                                            ]
+                                                 }
+                               },
+                               {
+                                   "id":  "t5",
+                                   "title":  "Add prescriptive change lifecycle rule to main.md",
+                                   "status":  "completed",
+                                   "narrative":  {
+                                                     "Action":  "Add mandatory /deft:change rule to Decision Making section of Agent Behavior",
+                                                     "AcceptanceCriteria":  [
+                                                                                "Rule added: \u0027! Before implementing any planned change that touches 3+ files or has an accepted plan artifact, propose /deft:change \u003cname\u003e and wait for confirmation\u0027",
+                                                                                "Placed in Decision Making block of Agent Behavior section"
+                                                                            ]
+                                                 }
+                               },
+                               {
+                                   "id":  "t6",
+                                   "title":  "Remove Skills line from in-repo AGENTS.md",
+                                   "status":  "completed",
+                                   "narrative":  {
+                                                     "Action":  "Remove the \u0027Skills: SKILL.md, skills/deft-setup/SKILL.md, skills/deft-build/SKILL.md\u0027 line from AGENTS.md â€” .agents/skills/ now handles discovery",
+                                                     "AcceptanceCriteria":  [
+                                                                                "Skills: line removed from AGENTS.md",
+                                                                                "AGENTS.md still contains bootstrap logic and commands from #54"
+                                                                            ]
+                                                 }
+                               },
+                               {
+                                   "id":  "t7",
+                                   "title":  "Run task check and verify all tests pass",
+                                   "status":  "completed",
+                                   "narrative":  {
+                                                     "Action":  "Run task check to verify fmt, lint, and all tests pass",
+                                                     "AcceptanceCriteria":  [
+                                                                                "go test ./cmd/deft-install/... passes",
+                                                                                "TestWriteAgentsSkills_CreateNew passes",
+                                                                                "TestWriteAgentsSkills_Idempotent passes",
+                                                                                "TestPrintNextSteps passes with updated assertions",
+                                                                                "TestWriteAgentsMD_* tests pass",
+                                                                                "No regressions"
+                                                                            ]
+                                                 }
+                               }
+                           ],
+                 "edges":  [
+                               {
+                                   "from":  "t2",
+                                   "to":  "t4",
+                                   "type":  "blocks"
+                               },
+                               {
+                                   "from":  "t3",
+                                   "to":  "t4",
+                                   "type":  "blocks"
+                               },
+                               {
+                                   "from":  "t4",
+                                   "to":  "t7",
+                                   "type":  "blocks"
+                               },
+                               {
+                                   "from":  "t1",
+                                   "to":  "t7",
+                                   "type":  "blocks"
+                               },
+                               {
+                                   "from":  "t5",
+                                   "to":  "t7",
+                                   "type":  "blocks"
+                               },
+                               {
+                                   "from":  "t6",
+                                   "to":  "t7",
+                                   "type":  "blocks"
+                               }
+                           ]
+             }
+}

--- a/main.md
+++ b/main.md
@@ -46,6 +46,7 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 - ~ Question assumptions and probe for clarity
 - ! Explain tradeoffs when multiple approaches exist
 - ~ Suggest improvements even when not asked
+- ! Before implementing any planned change that touches 3+ files or has an accepted plan artifact, propose `/deft:change <name>` and wait for confirmation
 
 **Communication:**
 - ! Be concise and precise


### PR DESCRIPTION
## Description

Closes #94

Implements two complementary fixes so agents auto-align with deft on startup and follow the correct change lifecycle:

1. **Skill auto-discovery** — thin .agents/skills/ pointer files committed to the repo and written by the installer so Warp and compatible agents discover deft skills without any user prompting.
2. **Prescriptive change lifecycle rule** — main.md now mandates /deft:change before multi-file planned work, not just lists it as an option.

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Code refactoring
- [x] test: Adding or updating tests
- [ ] chore: Maintenance or tooling

## Changes

- Added .agents/skills/deft/, deft-setup/, deft-build/ thin pointer SKILL.md files to repo (developer auto-alignment)
- Added WriteAgentsSkills to installer — creates .agents/skills/ in user project root on install (user project auto-alignment); idempotent
- Removed Skills: line from gentsMDEntry and in-repo AGENTS.md — .agents/skills/ now handles discovery
- Added prescriptive change lifecycle rule to main.md Decision Making section
- Updated PrintNextSteps to reflect partial auto-discovery with honest fallback instruction
- Added TestWriteAgentsSkills_CreateNew and TestWriteAgentsSkills_Idempotent tests
- Updated existing test assertions for new messaging and content

## Testing

- [x] Unit tests added/updated
- [x] Integration tests pass
- [ ] Coverage ≥75%
- [x] Manual testing completed (local build tested against test project)

## Checklist

- [x] Code follows project style guidelines (gofmt clean)
- [x] Self-reviewed code and comments
- [x] Updated documentation (CHANGELOG.md [Unreleased] updated)
- [x] No breaking changes
- [ ] \	ask check\ passes — 5 pre-existing failures in ROADMAP.md, specs/testbed/SPECIFICATION.md, history/todo-2026-03-13-retired.md (deprecated path/name refs, not touched by this branch, tracked in #58)

## Related Issues

Closes #94
Relates to #75 (skill auto-discovery infrastructure — thin pointer approach implemented here)
