### PR TITLE
docs(roadmap): triage issues #101–#108

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,11 +11,13 @@ Fix reported bugs and UX problems blocking adoption.
 ### Adoption Blockers (user-reported, highest priority)
 
 - **#105** — Add build output validation directive for custom build scripts (user-impacting directive gap: silent dist/ failures not caught by existing rules)
-
+- **#106** — Add toolchain/environment validation gate before implementation (user-impacting: agent completed full workflow without required toolchain installed)
 - **#94** — Agent auto-alignment on startup: thin .agents/skills/deft/SKILL.md pointer (no symlinks/copies) + prescriptive change lifecycle rule in main.md (depends on #54)
 - **#54** — AGENTS.md provides no actionable onboarding — agents don't know what to do after deft-install; installer 'Next steps' lies about automatic behavior; README lacks kick-off instructions (absorbed #85)
 - **#79** — deft-setup Phase 2 inference bleeds into `./deft/` framework internals (misidentifies project as "deft")
 - **#80** — deft-setup Phase 2 project name inference has no fallback when no build files exist
+- **#107** — Remove language defaults from USER.md — language is a project-level concern (deft-setup interview noise)
+- **#108** — Ask deployment platform before language — platform context drives language shortlist (depends on #107)
 - **#72** — vBRIEF files still invalid on master — users get non-conforming JSON output
 - **#68** — Warp not always enforcing Deft testing protocols (core quality gates silently skipped)
 
@@ -65,8 +67,8 @@ Quick doc/content fixes that don't require code changes.
 - Create `meta/philosophy.md` — full contract hierarchy narrative for agent reference and direct user reading (#84 Phase 2)
 - **#82** — Replacement strategies need accept-or-scrap exit when plan artifacts already exist (design: artifact awareness for chaining gate)
 - **#81** — Add BDD/acceptance-test-first strategy (`strategies/bdd.md` — Given/When/Then scenarios drive requirements)
-- **#103** — Standalone brownfield/map analysis without requiring interview (allow `/deft:run:map` as independent entry point)
 - **#102** — Codify Mermaid gist-rendering best practices as must/should rules (`coding/mermaid.md`)
+- **#103** — Standalone brownfield/map analysis without requiring interview (allow `/deft:run:map` as independent entry point)
 - **#104** — Add Holzmann Power of 10 rules as opt-in coding standard (`coding/holzmann.md`)
 - Add missing strategies:
   - `strategies/rapid.md` — Quick prototypes, SPECIFICATION only workflow
@@ -224,11 +226,15 @@ Larger feature work — only after issues are resolved and content is stable.
 | ~~#85~~ | ~~Installer instructions inaccurate/unclear~~ | closed — absorbed by #54 |
 | #95 | Compliance templates + readiness scanners (SOC 2, ISO 27001, HIPAA; sub-issues #96-#100) | 5 |
 | #86 | Artifact-branch binding and complete audit trail for SDD | 5 |
-|| #89 | Deft identity and positioning: resolve naming before README reframe | 2 |
-|| ~~#101~~ | ~~Should manual clone path exist?~~ | closed — absorbed by #56 |
-|| #102 | Codify Mermaid gist-rendering best practices | 2 |
-|| #103 | Standalone brownfield/map analysis without requiring interview | 2 |
-|| #104 | Holzmann Power of 10 rules (`coding/holzmann.md`) | 2 |
+| #89 | Deft identity and positioning: resolve naming before README reframe | 2 |
+| ~~#101~~ | ~~Should manual clone path exist?~~ | closed — absorbed by #56 |
+| #102 | Codify Mermaid gist-rendering best practices | 2 |
+| #103 | Standalone brownfield/map analysis without requiring interview | 2 |
+| #104 | Holzmann Power of 10 rules (`coding/holzmann.md`) | 2 |
+| #105 | Build output validation directive for custom build scripts | 1 |
+| #106 | Toolchain/environment validation gate before implementation | 1 |
+| #107 | Remove language defaults from USER.md | 1 |
+| #108 | Ask deployment platform before language | 1 |
 
 ---
 


### PR DESCRIPTION
## Summary

Triages 8 new issues into the roadmap:

### Phase 1 (Adoption Blockers)
- **#105** — Build output validation directive (user-impacting directive gap)
- **#106** — Toolchain/environment validation gate (user-impacting directive gap)
- **#107** — Remove language defaults from USER.md (project-level concern)
- **#108** — Platform-driven language shortlist (depends on #107)

### Phase 2 (Content & Doc Fixes)
- **#102** — Codify Mermaid gist-rendering best practices
- **#103** — Standalone brownfield/map analysis without interview
- **#104** — Holzmann Power of 10 rules (coding/holzmann.md)

### Closed
- **#101** — Absorbed into #56 (install path decision deferred to Phase 4)

Also updates #56 description to include absorbed #101 scope.