### PR TITLE
docs(swarm): lessons learned and skill fixes from first 4-agent run

### DIFF
--- a/meta/lessons.md
+++ b/meta/lessons.md
@@ -81,6 +81,38 @@ Two agents working the same repo on different branches need separate working dir
 
 Agent 1 created its PR and stopped before running the Greptile review cycle (the prompt's Step 9). Agent 2 ran 4 autonomous review rounds successfully. The difference was prompt structure. A monitoring agent MUST check whether each spawned agent completed the full workflow and be prepared to finish incomplete steps.
 
+## Parallel Agent Swarm — First Full Run (2026-04)
+
+**Source:** 4-agent swarm on Phase 1 roadmap items — PRs #154, #155, #156, #157 (14 issues closed)
+
+**1. `oz agent run` launches CLOUD agents, not local agents — MUST NOT use for local execution**
+
+The `oz` CLI always spawns agents on remote VMs, even when run from a local Warp tab. The swarm skill originally used `oz agent run --prompt` in launch scripts, expecting local execution. All 4 agents ran on cloud VMs instead, losing MCP server access, codebase indexing, and Warp Drive rules. For truly local agent execution, the user MUST paste the prompt directly into a Warp agent conversation (the chat input). `oz agent run` is the cloud path.
+
+**2. Warp terminal tabs MUST NOT be assumed openable programmatically**
+
+There is no API or CLI command to open a new Warp terminal tab from an agent or script. When the user said "launch", the monitor agent silently used `Start-Process` to open standalone PowerShell windows instead of asking the user to open Warp tabs manually. The user expected Warp tabs with full context. Agents MUST present the tradeoffs (local vs. cloud vs. standalone) and let the user choose before launching.
+
+**3. Sequential merging of PRs with shared append-only files causes rebase cascades**
+
+CHANGELOG.md and SPECIFICATION.md are "append-only" shared files — each agent adds entries without editing existing content. However, when PRs are merged sequentially, each merge changes the file at the same insertion point, causing merge conflicts for remaining PRs. Merging #154 conflicted #155 and #157; merging #155 conflicted #157 again. Each conflict required rebase → push → wait for checks (~3 min). Four PRs required 3 rebase cycles. SHOULD merge all PRs in rapid succession or rebase all remaining PRs before starting merges.
+
+**4. File-overlap audit MUST check transitive file touches, not just primary scope**
+
+The file-overlap audit assigned `skills/deft-review-cycle/SKILL.md` exclusively to Agent 3. But Agent 2 (enforcement rules, #123) added a `/deft:change` verification step to the same file as part of strengthening the review cycle's Phase 1 audit. This was a transitive touch — the enforcement task's acceptance criteria required changes to a file in another agent's scope. The overlap audit MUST trace each task's acceptance criteria to specific files, not just the task's primary scope.
+
+**5. SPECIFICATION.md task status MUST be verified before assigning work**
+
+The original Agent 2 was scoped to #31 and #50 (strategy consolidation). Both had spec tasks (t1.4.1, t1.4.2) marked `[completed]` in SPECIFICATION.md, but the ROADMAP.md still listed them as open. Verifying the spec caught this before agents wasted time reimplementing done work. The select phase MUST cross-reference ROADMAP.md against SPECIFICATION.md status before assigning.
+
+**6. PR numbers don't match agent numbers — include agent ID in branch/PR naming**
+
+GitHub assigns PR numbers in creation order, which depends on which cloud agent finishes first. Agent 2's PR became #154 while Agent 1's became #156. This caused confusion during monitoring and merging. Branch names SHOULD include the agent number (e.g. `agent1/fix/...`) or PR titles SHOULD include `[Agent N]` for traceability.
+
+**7. Cloud agents stop after PR creation — review cycle requires separate launch**
+
+All 4 agents (running as cloud agents via `oz agent run`) completed through Step 5 (push + PR creation) but stopped before Step 6 (review cycle). The review cycle had to be launched as a separate swarm pass. When using cloud agents, SHOULD expect the workflow to require at least two passes: implementation + review cycle.
+
 ## Windows File Editing (2026-03)
 
 **Source:** ROADMAP.md edits during feat/agents-md-onboarding-54 — three sequential failures before clean write

--- a/skills/deft-swarm/SKILL.md
+++ b/skills/deft-swarm/SKILL.md
@@ -36,6 +36,7 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
 - ! Read ROADMAP.md for open items, prioritizing Phase 1 before Phase 2
 - ! Read SPECIFICATION.md for acceptance criteria of candidate tasks
+- ! Cross-reference ROADMAP.md items against SPECIFICATION.md task status — if a roadmap item has a spec task marked `[completed]`, verify the work is actually done (check files) before assigning. ROADMAP.md may lag behind SPECIFICATION.md.
 - ! Exclude items that are blocked, have unresolved dependencies, or require design decisions
 
 ### Step 2: File-Overlap Audit
@@ -43,10 +44,12 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 ! Before assigning tasks to agents, list every file each task is expected to touch.
 
 - ! Verify ZERO file overlap between agents — no two agents may modify the same file
+- ! Check **transitive** file touches, not just primary scope — trace each task's acceptance criteria to specific files. A task may require changes to files outside its obvious scope (e.g., an enforcement task adding an anti-pattern to a skill file owned by another agent).
 - ! Shared files (CHANGELOG.md, SPECIFICATION.md) are exceptions — each agent adds entries but does not edit existing content
 - ! If overlap exists, reassign tasks until overlap is eliminated
 
 ⊗ Proceed to Phase 2 while any file overlap exists between agents (excluding shared append-only files).
+⊗ Assume a task only touches files in its primary scope — always check acceptance criteria for cross-file requirements.
 
 ### Step 3: Present Assignment
 
@@ -64,7 +67,7 @@ git worktree add <path> -b <branch-name> master
 ```
 
 - ! One worktree per agent (e.g. `E:\Repos\deft-agent1`, `E:\Repos\deft-agent2`)
-- ! Branch naming: `<type>/<issue-numbers>-<short-description>` (e.g. `cleanup/31-50-23-strategy-consolidation`)
+- ! Branch naming: `agent<N>/<type>/<issue-numbers>-<short-description>` (e.g. `agent1/cleanup/31-50-23-strategy-consolidation`) — the agent number prefix aids traceability since GitHub PR numbers won't match agent numbers
 - ! All worktrees branch from the same base (typically `master`)
 
 ### Step 2: Generate Prompt Files
@@ -172,9 +175,14 @@ All PRs meet ALL of:
 
 ### Step 1: Merge
 
+! **Merge cascade warning:** Shared append-only files (CHANGELOG.md, SPECIFICATION.md) cause merge conflicts when PRs are merged sequentially — each merge changes the insertion point, conflicting remaining PRs. Each conflict requires rebase → push → wait for checks (~3 min). Plan for N-1 rebase cycles when merging N PRs.
+
+~ To minimize cascades: rebase ALL remaining PRs onto latest master before starting any merges, then merge in rapid succession.
+
 - ! Undraft PRs: `gh pr ready <number> --repo <owner/repo>`
 - ! Squash merge: `gh pr merge <number> --squash --delete-branch --admin` (if branch protection requires)
 - ! Use descriptive squash subject: `type(scope): description (#issues)`
+- ! After each merge, rebase remaining PRs onto updated master before merging the next
 
 ### Step 2: Close Issues
 


### PR DESCRIPTION
## Summary

Post-swarm improvements to skills/deft-swarm/SKILL.md and meta/lessons.md from the first full 4-agent parallel run (PRs #154, #155, #156, #157 — 14 issues closed).

## Changes

### Skill fixes (skills/deft-swarm/SKILL.md)
- **oz CLI distinction**: Clarified that \oz agent run\ launches cloud agents, not local — added 3 launch options (Warp tabs / oz CLI / standalone)
- **Tab warning**: Warp tabs cannot be opened programmatically — agent must present tradeoffs before launching
- **SPEC status verification**: Cross-reference ROADMAP items against SPECIFICATION task status before assigning
- **Transitive file-overlap audit**: Check acceptance criteria for cross-file touches, not just primary scope
- **Agent ID in branch naming**: \gent<N>/<type>/...\ prefix for traceability (PR numbers don't match agent numbers)
- **Merge cascade warning**: Document rebase cycles for shared append-only files, add rebase-before-merge guidance

### Lessons learned (meta/lessons.md)
7 new lessons from the swarm session covering: cloud vs local execution, programmatic tab opening, merge cascades, transitive overlap, SPEC verification, PR numbering, and cloud agent workflow gaps.

## Checklist
- [x] CHANGELOG.md — N/A (docs-only, no user-facing behavior change)
- [x] Tests pass locally