### PR TITLE
docs(roadmap): 2026-04-03 roadmap refresh — stale cleanup + triage 6 new issues

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,7 +73,7 @@ Quick doc/content fixes that don't require code changes.
 - ~~Write remaining CHANGELOG entries~~ — tracked by #71 (Phase 1)
 - **#112** — External “Deft Directive” PDF is premature — describes post-Phase-1-3 state; defer distribution or add known-issues caveat; incorporate as `docs/getting-started.md` after Phases 1–3 ship
 - **#114** — Document all global Warp rules used for deft development; migrate project-scope rules to `AGENTS.md`/`CONVENTIONS.md`; inventory remaining global-only rules in `CONTRIBUTING.md`
-- **#136** — Warp doesn't load deft's AGENTS.md by default
+- **#136** — Warp doesn't load deft's AGENTS.md by default — document global rule workaround in README/installer output; real fix is Warp platform feature request (to be done with #114)
 - **#146** — Add `skills/deft-sync/SKILL.md` — session-start sync skill: submodule update, vBRIEF file validation, AGENTS.md freshness check, new-skills listing; design complete in issue body (related: #140 CLI counterpart, #75 auto-discovery)
 - **#147** — Skills `deft-roadmap-refresh` and `deft-review-cycle` not documented in README or AGENTS.md — add to README directory tree and `### 🤖 Skills` section; add `deft-roadmap-refresh` reference to AGENTS.md (to be done with #114)
 
@@ -324,5 +324,5 @@ Larger feature work — only after issues are resolved and content is stable.
 *Updated 2026-04-02 — roadmap refresh: added #146 to Phase 2 (deft-sync skill, session-start framework sync); added #147 to Phase 2 (skills undocumented in README/AGENTS.md)*
 *Updated 2026-04-02 — note: #143 is a merged PR (feat: add deft-review-cycle skill, PR #143), not an open issue; correctly absent from triage*
 *Updated 2026-04-02 — added #163 to Phase 3 (Enforce USER.md gate in CLI path — parity with agentic skills path)*
-*Updated 2026-04-03 — stale entry cleanup: moved 21 closed issues (#23–#145) from Phase 1/2 body to Completed section; struck through in Open Issues Index; closed #104, #137, #145 on GitHub*
+*Updated 2026-04-03 — stale entry cleanup: moved 21 closed issues (#23, #24, #25, #31, #49, #50, #59, #68, #79, #80, #107, #108, #118, #123, #131, #135, #137, #138, #139, #142, #145) from Phase 1/2 body to Completed section; struck through in Open Issues Index; closed #104, #137, #145 on GitHub*
 *Updated 2026-04-03 — roadmap refresh triage: added #166 (Greptile re-review, Phase 1), #167 (PR merge hygiene, Phase 1), #151 (playtest feedback umbrella, Phase 2), #159 (deterministic principle, Phase 2), #160 (TypeScript CLI, Phase 5), #168 (skill transparency, Phase 2)*


### PR DESCRIPTION
## Summary

Periodic roadmap refresh: cleaned 21 stale entries from Phase 1/2, triaged 6 new issues into the roadmap, closed 3 issues on GitHub that were completed but never closed.

### Stale Entry Cleanup
- Moved 21 closed issues from Phase 1/2 body sections to Completed
- Struck through all 21 in Open Issues Index with version annotations
- Closed #104, #137, #145 on GitHub (merged via PRs but never closed)
- Updated partially-done sub-items (#84 Phase 1, core/project.md cleanup)

### New Issue Triage
- **#166** Greptile re-review blocks merge → Phase 1 Adoption Blockers
- **#167** PRs merged but issues not closed → Phase 1 Cleanup
- **#151** Playtest feedback (umbrella, 19 sub-issues) → Phase 2
- **#159** Deterministic > Probabilistic principle → Phase 2
- **#160** Consider TypeScript for CLI → Phase 5
- **#168** Skill transparency rule for analysis comments → Phase 2

All 6 issues have analysis comments posted on GitHub.

## Related Issues

Partially addresses #167 (this refresh discovered the pattern that prompted the issue)

## Checklist

- [x] \/deft:change <name>\ — N/A (docs-only roadmap maintenance, <3 code files changed)
- [x] \CHANGELOG.md\ — N/A (roadmap refresh is tracked via ROADMAP.md changelog lines, not CHANGELOG.md)
- [x] \ROADMAP.md\ — this PR IS the roadmap update
- [x] Tests pass locally — no code changes