### PR TITLE
fix(swarm,review-cycle): add close-out orchestration rules for start_agent monitor workflow (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Swarm close-out orchestration rules** (#206, t2.6.3): Added monitor-centric close-out rules to skills/deft-swarm/SKILL.md Phase 6 -- merge authority (monitor proposes, user approves), rebase cascade ownership (monitor owns), GIT_EDITOR=true for non-interactive rebase, post-merge issue verification step; added push autonomy carve-out for swarm agents; added MCP fallback note to skills/deft-review-cycle/SKILL.md (gh-only when MCP unavailable)
 - **Deft-swarm runtime capability detection** (#188, t1.9.3): Replaced static Option A/B/C launch path selection in `skills/deft-swarm/SKILL.md` Phase 3 with runtime capability detection — agent probes for `start_agent` tool at runtime, uses it as preferred path if available (Warp orchestration), falls back to manual Warp tabs silently when unavailable but Warp detected, gates Warp-specific paths on `WARP_*` environment variables; cloud (`oz agent run-cloud`) preserved as explicit user-requested escape hatch only; anti-patterns updated for dynamic approach
 - **Deft-swarm mandatory analyze phase** (#199, t1.9.4): Added Phase 0 — Analyze to `skills/deft-swarm/SKILL.md` before Phase 1 (Select) — reads ROADMAP.md and SPECIFICATION.md, surfaces blockers (blocked spec tasks, missing spec coverage, dependency conflicts), presents analysis summary to user, requires explicit user approval before proceeding to task selection; anti-pattern added prohibiting Phase 1 entry without Phase 0 completion
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -575,6 +575,18 @@ skills/deft-swarm/SKILL.md Anti-Patterns contains ⊗ entry: update ROADMAP.md d
 
 **Traces**: #170
 
+## t2.6.3: Add close-out orchestration rules for start_agent monitor workflow (#206)  [completed]
+
+The deft-swarm skill lacks orchestration-specific close-out rules for the start_agent monitor workflow. Add merge authority, rebase cascade ownership, GIT_EDITOR override, post-merge issue verification, MCP fallback, and push autonomy carve-out. Closes #206.
+
+- skills/deft-swarm/SKILL.md Phase 6 Step 1 contains ! rules for: monitor proposes merge order (user approves), monitor owns rebase cascade, GIT_EDITOR=true before non-interactive rebase
+- skills/deft-swarm/SKILL.md Phase 6 contains post-merge issue verification step
+- skills/deft-swarm/SKILL.md contains push autonomy carve-out for swarm agents
+- skills/deft-review-cycle/SKILL.md contains ~ MCP fallback note (gh-only when MCP unavailable)
+- tests/content/test_skills.py passes
+
+**Traces**: #206
+
 ## t3.1.1: Write .github/workflows/ci.yml — lint + test on PRs and master pushes (FR-25, FR-26)  `[pending]`
 
 GitHub Actions CI workflow triggering on pull_request and push to master. Jobs: (1) Python: ruff check, mypy tests/ (the shim run.py cannot be typed directly - exclude run and run.py from mypy per pyproject.toml, type-check the test suite instead), pytest tests/ with coverage. (2) Go: go test ./cmd/deft-install/ + go build ./cmd/deft-install/ for each platform matrix (linux/amd64, darwin/arm64, windows/amd64). main_test.go already exists so go test is zero-cost. Use current action versions. Closes #57.

--- a/skills/deft-review-cycle/SKILL.md
+++ b/skills/deft-review-cycle/SKILL.md
@@ -167,6 +167,8 @@ If the exit condition is not met, go back to Step 2.
 
 Choose whichever minimizes steps and maximizes clarity for the given task.
 
+~ When MCP is unavailable (`start_agent` agents, cloud agents, `oz agent run`), `gh` CLI is sufficient as the sole interface. The dual-source requirement (MCP + `gh`) in Step 1 applies only when both are available -- agents without MCP access should use `gh pr view --comments` and `gh api` as their primary and only review detection surface.
+
 ## Anti-Patterns
 
 - ⊗ Push individual fix commits per finding

--- a/skills/deft-swarm/SKILL.md
+++ b/skills/deft-swarm/SKILL.md
@@ -225,6 +225,12 @@ All PRs meet ALL of:
 
 ### Step 1: Merge
 
+! **Merge authority:** Monitor proposes merge order and executes merges; user approves before the first merge. Do not merge without explicit user approval.
+
+! **Rebase cascade ownership:** Monitor owns rebase cascade sequencing. Swarm agents do not rebase -- by the time merges begin, swarm agents are idle or complete. The monitor fetches updated master, rebases each remaining branch, resolves conflicts, and force-pushes.
+
+! **Non-interactive rebase:** Monitor MUST set `GIT_EDITOR=true` (or equivalent no-op) before running `git rebase --continue` during merge cascade to prevent the default editor from blocking the agent.
+
 ! **Merge cascade warning:** Shared append-only files (CHANGELOG.md, SPECIFICATION.md) cause merge conflicts when PRs are merged sequentially — each merge changes the insertion point, conflicting remaining PRs. Each conflict requires rebase → push → wait for checks (~3 min). Plan for N-1 rebase cycles when merging N PRs.
 
 ~ To minimize cascades: rebase ALL remaining PRs onto latest master before starting any merges, then merge in rapid succession.
@@ -237,7 +243,8 @@ All PRs meet ALL of:
 ### Step 2: Close Issues
 
 - ! Close resolved issues with a comment referencing the PR
-- ~ Issues with "Closes #N" in PR body auto-close on merge
+- ~ Issues with "Closes #N" in PR body auto-close on squash merge
+- ! After each squash merge, verify issues actually closed: `gh issue view <N> --json state --jq .state`. If not closed, close manually with a comment referencing the merged PR. Squash merge + closing keywords can silently fail to close issues (#167).
 
 ### Step 3: Update Master
 
@@ -302,6 +309,10 @@ CONSTRAINTS:
 - ! CONSTRAINTS section MUST list files the agent must not touch (other agents' scope)
 - ! Review cycle step MUST reference `skills/deft-review-cycle/SKILL.md` explicitly
 - ⊗ Start the prompt with context ("You are working in...") — agents treat this as passive setup and may stop after reading
+
+## Push Autonomy
+
+! Swarm agents operating under this skill with a monitor agent may push, create PRs, and run review cycles autonomously after passing `task check`. The global "never push/commit without explicit user instruction" convention does not apply to swarm agents executing the full STEP 1-6 prompt workflow -- the skill's quality gates (`task check`, Greptile review cycle) replace the interactive confirmation gate.
 
 ## Anti-Patterns
 


### PR DESCRIPTION
## Summary

Add close-out orchestration rules for the `start_agent` monitor workflow to the deft-swarm and deft-review-cycle skills. Addresses friction points observed during the first `start_agent` orchestrated swarm run (PRs #204, #205).

## Changes

**`skills/deft-swarm/SKILL.md` Phase 6:**
- Merge authority: monitor proposes order, user approves, monitor executes
- Rebase cascade ownership: monitor owns sequencing, swarm agents do not rebase
- `GIT_EDITOR=true` rule for non-interactive rebase during merge cascade
- Post-merge issue verification step (`gh issue view --json state`)
- Push autonomy carve-out for swarm agents under deft-swarm workflow

**`skills/deft-review-cycle/SKILL.md`:**
- MCP fallback note: `gh` CLI sufficient when MCP unavailable

**`SPECIFICATION.md`:**
- Added spec task t2.6.3 (completed)

**`CHANGELOG.md`:**
- Added entry under [Unreleased]

## Checklist
- [x] SPECIFICATION.md has task coverage (t2.6.3)
- [x] CHANGELOG.md entry under [Unreleased]
- [x] `task check` passes (859 passed, 25 xfailed)
- [x] N/A for /deft:change (docs-only, <3 conceptual changes per file)

Closes #206
