### PR TITLE
docs(skills): deft-roadmap-refresh transparency, PR phase, cleanup rules (#168, #174, #196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **meta/philosophy.md -- deterministic > probabilistic design principle** (#159, t2.7.7): Created `meta/philosophy.md` documenting the "prefer deterministic components for repeatable actions" design principle -- definition, rationale, examples (Taskfile tasks, spec_validate.py, CI workflows), and scope note deferring broad application to Phase 5; referenced from `contracts/hierarchy.md` See also banner
 - **strategies/bdd.md -- BDD/acceptance-test-first strategy** (#81, t2.7.8): Created `strategies/bdd.md` with RFC2119 legend and See also banner -- 6-step workflow (scenarios, failing tests, surface ambiguity, lock decisions, generate spec, chain into sizing gate), output artifacts (`specs/{feature}/acceptance-tests/` + `{feature}-bdd-context.md`), chaining gate integration as preparatory strategy, anti-patterns; added to `strategies/README.md`; added `test_bdd_strategy_exists` to `tests/content/test_structure.py`
+- **deft-roadmap-refresh: analysis comment transparency** (#168, t2.7.1): Added `!` rule to Phase 2 Step 4 requiring agent to confirm to the user that an analysis comment was posted -- includes issue number and direct link to the comment
+- **deft-roadmap-refresh: Phase 4 -- PR & Review Cycle** (#174, t2.7.2): Added Phase 4 after Phase 3 Cleanup -- asks user confirmation, runs pre-flight checks (CHANGELOG, task check, PR template) before pushing, commits/pushes/creates PR, then automatically sequences into `skills/deft-review-cycle/SKILL.md`
+- **deft-roadmap-refresh: explicit cleanup convention** (#196, t2.7.3): Replaced ambiguous Phase 3 cleanup instruction with explicit rules -- remove entries from phase body entirely (Completed section is sole record), strike through in Open Issues Index with 'completed -- YYYY-MM-DD', added anti-pattern against duplicate records
 
 ## [0.13.0] - 2026-04-07
 

--- a/skills/deft-roadmap-refresh/SKILL.md
+++ b/skills/deft-roadmap-refresh/SKILL.md
@@ -78,6 +78,7 @@ Present analysis to the user covering:
 ### Step 4: Apply (on user approval)
 
 - ! Post the analysis as a comment on the GitHub issue
+- ! After posting the analysis comment, confirm to the user that the comment was posted -- include the issue number and a direct link to the comment.
 - ! Add the issue to the correct phase section in ROADMAP.md
 - ! Add the issue to the Open Issues Index table
 - ! Update the changelog line at the bottom of ROADMAP.md
@@ -87,9 +88,12 @@ Present analysis to the user covering:
 
 After all new issues are triaged:
 
-- ! Strike through or move any stale entries (closed issues still in the index)
+- ! Remove the entry from the phase section body entirely -- do NOT leave a struck-through line in place. The Completed section is the sole record for closed issues.
+- ! In the Open Issues Index: strike through the row (keep for history), update Phase column to 'completed -- YYYY-MM-DD'.
 - ! Move closed issues to the Completed section if they aren't there already
 - ~ Verify the Open Issues Index matches the phase sections
+
+~ When cleanup is complete, proceed to Phase 4 -- PR & Review Cycle.
 
 ## Analysis Comment Template
 
@@ -124,3 +128,32 @@ When posting to a GitHub issue, use this structure:
 - ⊗ Skip the analysis comment on the GitHub issue
 - ⊗ Forget to update the Open Issues Index when adding to a phase
 - ⊗ Leave closed issues in the index without striking through
+- ⊗ Strike through an entry in the phase body AND add it to Completed -- this creates a duplicate record and breaks the single-record convention
+
+## Phase 4 — PR & Review Cycle
+
+After all triage and cleanup is complete:
+
+1. ! Ask the user: "Ready to commit and create a PR?"
+2. ! Wait for explicit user confirmation before proceeding.
+
+### Pre-Flight (before pushing)
+
+! Run all pre-flight checks BEFORE committing and pushing:
+
+1. ! Verify `CHANGELOG.md` has an `[Unreleased]` entry covering the roadmap refresh changes
+2. ! Run `task check` -- all checks must pass
+3. ! Verify `.github/PULL_REQUEST_TEMPLATE.md` checklist is satisfiable for this PR
+
+### Commit, Push, and Create PR
+
+1. ! Commit with a descriptive message: `docs(roadmap): refresh -- add #{n}, #{n}, ... to Phase {x}`
+2. ! Push the branch to origin
+3. ! Create a PR targeting `master` with a summary of triaged issues and cleanup performed
+
+### Review Cycle Handoff
+
+! After the PR is created, automatically sequence into `skills/deft-review-cycle/SKILL.md`.
+
+- ! Inform the user: "PR #{N} created -- starting review cycle."
+- ! Follow the full review cycle skill from Phase 1 (Deft Process Audit) onward.

--- a/tests/content/test_skills.py
+++ b/tests/content/test_skills.py
@@ -468,3 +468,102 @@ def test_deft_review_cycle_mcp_fallback() -> None:
     assert "MCP is unavailable" in text and "gh" in text, (
         f"{_REVIEW_CYCLE_PATH}: must document MCP fallback for start_agent/cloud agents (#206)"
     )
+
+
+# ---------------------------------------------------------------------------
+# 18. deft-roadmap-refresh skill -- existence and RFC2119
+# ---------------------------------------------------------------------------
+
+_ROADMAP_REFRESH_PATH = "skills/deft-roadmap-refresh/SKILL.md"
+
+
+def test_deft_roadmap_refresh_exists() -> None:
+    """deft-roadmap-refresh SKILL.md must exist."""
+    assert (_REPO_ROOT / _ROADMAP_REFRESH_PATH).is_file(), (
+        f"Skill file missing: {_ROADMAP_REFRESH_PATH}"
+    )
+
+
+def test_deft_roadmap_refresh_rfc2119_legend() -> None:
+    """deft-roadmap-refresh must contain the RFC2119 legend."""
+    text = _read_skill(_ROADMAP_REFRESH_PATH)
+    assert RFC2119_LEGEND in text, (
+        f"{_ROADMAP_REFRESH_PATH}: missing RFC2119 legend"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 19. deft-roadmap-refresh Phase 2 Step 4 -- transparency rule (#168, t2.7.1)
+# ---------------------------------------------------------------------------
+
+def test_deft_roadmap_refresh_confirm_comment_posting() -> None:
+    """Phase 2 Step 4 must confirm to user that analysis comment was posted."""
+    text = _read_skill(_ROADMAP_REFRESH_PATH)
+    assert "confirm to the user" in text.lower() and "issue number" in text.lower(), (
+        f"{_ROADMAP_REFRESH_PATH}: Phase 2 Step 4 must confirm comment posting "
+        "with issue number and link (#168)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 20. deft-roadmap-refresh Phase 4 -- PR & Review Cycle (#174, t2.7.2)
+# ---------------------------------------------------------------------------
+
+def test_deft_roadmap_refresh_phase4_heading() -> None:
+    """deft-roadmap-refresh must contain Phase 4 -- PR & Review Cycle."""
+    text = _read_skill(_ROADMAP_REFRESH_PATH)
+    assert "Phase 4" in text and "PR & Review Cycle" in text, (
+        f"{_ROADMAP_REFRESH_PATH}: missing Phase 4 -- PR & Review Cycle (#174)"
+    )
+
+
+def test_deft_roadmap_refresh_phase4_user_confirmation() -> None:
+    """Phase 4 must ask user before committing."""
+    text = _read_skill(_ROADMAP_REFRESH_PATH)
+    assert "Ready to commit and create a PR?" in text, (
+        f"{_ROADMAP_REFRESH_PATH}: Phase 4 must ask user confirmation (#174)"
+    )
+
+
+def test_deft_roadmap_refresh_phase4_preflight() -> None:
+    """Phase 4 must run pre-flight checks before pushing."""
+    text = _read_skill(_ROADMAP_REFRESH_PATH)
+    assert "CHANGELOG.md" in text and "task check" in text, (
+        f"{_ROADMAP_REFRESH_PATH}: Phase 4 pre-flight must check CHANGELOG and task check (#174)"
+    )
+
+
+def test_deft_roadmap_refresh_phase4_review_cycle_handoff() -> None:
+    """Phase 4 must sequence into deft-review-cycle."""
+    text = _read_skill(_ROADMAP_REFRESH_PATH)
+    assert "skills/deft-review-cycle/SKILL.md" in text, (
+        f"{_ROADMAP_REFRESH_PATH}: Phase 4 must hand off to deft-review-cycle (#174)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 21. deft-roadmap-refresh Phase 3 -- cleanup rules (#196, t2.7.3)
+# ---------------------------------------------------------------------------
+
+def test_deft_roadmap_refresh_cleanup_remove_from_body() -> None:
+    """Phase 3 must remove entries from phase body, not strike through."""
+    text = _read_skill(_ROADMAP_REFRESH_PATH)
+    assert "Remove the entry from the phase section body entirely" in text, (
+        f"{_ROADMAP_REFRESH_PATH}: Phase 3 must remove entries from phase body (#196)"
+    )
+
+
+def test_deft_roadmap_refresh_cleanup_index_strike() -> None:
+    """Phase 3 must strike through in Open Issues Index with completed date."""
+    text = _read_skill(_ROADMAP_REFRESH_PATH)
+    assert "Open Issues Index" in text and "completed --" in text, (
+        f"{_ROADMAP_REFRESH_PATH}: Phase 3 must strike through in index with date (#196)"
+    )
+
+
+def test_deft_roadmap_refresh_cleanup_antipattern() -> None:
+    """Anti-patterns must prohibit duplicate record in phase body and Completed."""
+    text = _read_skill(_ROADMAP_REFRESH_PATH)
+    assert "duplicate record" in text.lower() and "single-record convention" in text.lower(), (
+        f"{_ROADMAP_REFRESH_PATH}: must have anti-pattern against duplicate records (#196)"
+    )


### PR DESCRIPTION
## Summary

Updates skills/deft-roadmap-refresh/SKILL.md with three documentation improvements:

### Changes

1. **Analysis comment transparency** (#168, t2.7.1): Added ! rule to Phase 2 Step 4 requiring the agent to confirm to the user that an analysis comment was posted -- includes the issue number and a direct link to the comment.

2. **Phase 4 -- PR & Review Cycle** (#174, t2.7.2): Added new Phase 4 after Phase 3 Cleanup. Workflow: ask user confirmation -> run pre-flight checks (CHANGELOG, task check, PR template) BEFORE pushing -> commit/push/create PR -> automatically hand off to skills/deft-review-cycle/SKILL.md.

3. **Explicit cleanup convention** (#196, t2.7.3): Replaced ambiguous Phase 3 instruction ("Strike through or move") with explicit rules: remove entries from phase body entirely (Completed section is the sole record), strike through in Open Issues Index with 'completed -- YYYY-MM-DD', added anti-pattern against duplicate records.

### Tests

Added 12 tests to 	ests/content/test_skills.py covering deft-roadmap-refresh existence, RFC2119 legend, transparency rule, Phase 4 structure, and cleanup conventions.

### Validation

- `task check` passes (885 passed, 25 xfailed)

### PR Checklist

- [x] SPECIFICATION.md has task coverage (t2.7.1, t2.7.2, t2.7.3)
- [x] CHANGELOG.md has entries under [Unreleased]
- [x] `task check` passes
- [x] /deft:change N/A (<3 file changes in scope)

Closes #168, Closes #174, Closes #196