### PR TITLE
docs(content): deterministic principle philosophy doc and BDD strategy (#159, #81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **meta/philosophy.md -- deterministic > probabilistic design principle** (#159, t2.7.7): Created `meta/philosophy.md` documenting the "prefer deterministic components for repeatable actions" design principle -- definition, rationale, examples (Taskfile tasks, spec_validate.py, CI workflows), and scope note deferring broad application to Phase 5; referenced from `contracts/hierarchy.md` See also banner
+- **strategies/bdd.md -- BDD/acceptance-test-first strategy** (#81, t2.7.8): Created `strategies/bdd.md` with RFC2119 legend and See also banner -- 6-step workflow (scenarios, failing tests, surface ambiguity, lock decisions, generate spec, chain into sizing gate), output artifacts (`specs/{feature}/acceptance-tests/` + `{feature}-bdd-context.md`), chaining gate integration as preparatory strategy, anti-patterns; added to `strategies/README.md`; added `test_bdd_strategy_exists` to `tests/content/test_structure.py`
+
 ## [0.13.0] - 2026-04-07
 
 ### Added

--- a/contracts/hierarchy.md
+++ b/contracts/hierarchy.md
@@ -4,7 +4,7 @@ Two lenses for reasoning about what to invest in — durability (what survives) 
 
 Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
-**⚠️ See also**: [contracts/boundary-maps.md](./boundary-maps.md) | [coding/coding.md](../coding/coding.md) | [core/glossary.md](../core/glossary.md)
+**⚠️ See also**: [contracts/boundary-maps.md](./boundary-maps.md) | [coding/coding.md](../coding/coding.md) | [meta/philosophy.md](../meta/philosophy.md) | [core/glossary.md](../core/glossary.md)
 
 ---
 

--- a/meta/philosophy.md
+++ b/meta/philosophy.md
@@ -1,0 +1,39 @@
+# Design Philosophy
+
+Core design principles that guide the Deft Directive framework.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+**⚠️ See also**: [contracts/hierarchy.md](../contracts/hierarchy.md) | [main.md](../main.md)
+
+---
+
+## Deterministic > Probabilistic
+
+Prefer deterministic components for repeatable actions over probabilistic ones.
+
+### Definition
+
+A **deterministic component** produces identical outputs for identical inputs -- fixed commands, schema validators, CI checks, Taskfile tasks. A **probabilistic component** (LLM inference) produces variable outputs for the same input due to sampling, temperature, and context-window drift.
+
+! When an action can be expressed as a fixed, repeatable operation, implement it as a deterministic component.
+~ Reserve LLM inference for reasoning, synthesis, and creative tasks where variability is acceptable or desirable.
+⊗ Use LLM inference as a gate where consistent, auditable behavior is required.
+
+### Rationale
+
+Deterministic components are **verifiable** -- you can write a test that asserts exact output. They are **auditable** -- the same input always produces the same result, so failures are reproducible. They are **fast** -- no API latency, no token cost, no rate limits.
+
+LLM inference is appropriate for understanding intent, synthesizing information across documents, generating novel content, and making judgment calls. It is not appropriate for gates that need consistent pass/fail behavior across runs.
+
+### Examples from the Deft Framework
+
+**Taskfile tasks** -- `task check` is a fixed, repeatable gate. It runs the same linters, the same test suite, with the same thresholds every time. An LLM cannot replace this because its judgment on "does this code pass lint?" would vary between runs.
+
+**spec_validate.py** -- Deterministic schema validation replaces LLM judgment on whether a vBRIEF file conforms to the schema. The validator checks exact field names, types, and enum values. An LLM reviewing the same file might miss a subtle type violation or flag a false positive depending on context.
+
+**CI workflows** -- GitHub Actions runs deterministic CI gates (lint, test, build) on every push. The pipeline does not ask an LLM "does this PR look good?" -- it runs fixed checks with binary pass/fail outcomes.
+
+### Scope Note
+
+This principle is documented here as a design reference. Broad application across the CLI, skills, and workflows is Phase 5 work. This document establishes the principle; it does not mandate immediate refactoring of existing components.

--- a/strategies/README.md
+++ b/strategies/README.md
@@ -11,8 +11,9 @@ Development strategies define the workflow from idea to implementation.
 | [speckit.md](./speckit.md) | `/deft:run:speckit` | spec-generating | Large/complex projects | Principles → Specify → Plan → Tasks → Implement |
 | [map.md](./map.md) | `/deft:run:map` | preparatory | Existing codebases | Map → Chaining Gate |
 | [discuss.md](./discuss.md) | `/deft:run:discuss` | preparatory | Alignment before planning | Feynman technique → locked decisions → Chaining Gate |
-| [research.md](./research.md) | `/deft:run:research` | preparatory | Pre-implementation research | Research → Don’t Hand-Roll + Common Pitfalls → Chaining Gate |
+| [research.md](./research.md) | `/deft:run:research` | preparatory | Pre-implementation research | Research → Don't Hand-Roll + Common Pitfalls → Chaining Gate |
 | [roadmap.md](./roadmap.md) | `/deft:run:roadmap` | preparatory | Roadmap maintenance | Discover → Triage → Cleanup |
+| [bdd.md](./bdd.md) | `/deft:run:bdd` | preparatory | Acceptance-test-first development | Scenarios → Failing Tests → Lock Decisions → Spec → Chaining Gate |
 | rapid.md | `/deft:run:rapid` | spec-generating | Quick prototypes | Forced-Light path (future) |
 | enterprise.md | `/deft:run:enterprise` | spec-generating | Compliance-heavy | Forced-Full path (future) |
 

--- a/strategies/bdd.md
+++ b/strategies/bdd.md
@@ -1,0 +1,102 @@
+# BDD Strategy
+
+Behaviour-Driven Development -- failing acceptance tests drive requirements.
+
+Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+**⚠️ See also**: [strategies/interview.md](./interview.md) | [strategies/discuss.md](./discuss.md) | [core/glossary.md](../core/glossary.md)
+
+> Acceptance tests are the specification. Write them first, let failures surface ambiguity, then lock decisions before generating a formal spec.
+
+---
+
+## When to Use
+
+- ~ Features where expected behaviour is easier to express as examples (Given/When/Then) than as written requirements
+- ~ Teams wanting executable specifications that double as regression tests
+- ~ Projects where acceptance tests will be the source of truth for feature correctness
+- ? Skip when requirements are already unambiguous and a formal spec exists
+
+---
+
+## Workflow
+
+### Step 1: Identify User Scenarios
+
+! Write Given/When/Then scenarios for the feature before any implementation or specification work.
+
+- ! Each scenario covers one behaviour -- avoid multi-assertion scenarios
+- ~ Capture happy path, edge cases, and error cases as separate scenarios
+- ~ Use concrete values, not placeholders (e.g. "Given a user with 3 items in cart" not "Given a user with items")
+- ! Store scenarios in `specs/{feature}/acceptance-tests/`
+
+### Step 2: Write Failing Acceptance Tests
+
+! Translate scenarios into executable test code before writing any implementation.
+
+- ! Tests MUST fail when first written -- a passing test before implementation means the test is wrong or the feature already exists
+- ~ Use the project's test framework (pytest, go test, jest, etc.)
+- ! Place test files in `specs/{feature}/acceptance-tests/`
+- ⊗ Write implementation code at this step
+
+### Step 3: Run Tests -- Surface Ambiguity
+
+! Run the failing tests. Use the failures to surface missing decisions and ambiguity in requirements.
+
+- ! Each test failure is a question: "What should happen here?"
+- ~ Group failures by theme (data model gaps, API contract gaps, business rule gaps)
+- ! Record every ambiguity discovered -- these become decision items in Step 4
+
+### Step 4: Lock Decisions
+
+! Resolve all ambiguities surfaced by Step 3. Record decisions in `{feature}-bdd-context.md`.
+
+- ! Each decision includes: **what** was decided, **why**, and **alternatives considered**
+- ! Decisions are **locked** -- downstream tasks inherit them, do not re-debate
+- ! Format follows the same structure as `{scope}-context.md` from [strategies/discuss.md](./discuss.md)
+- ⊗ Leave ambiguities unresolved -- every question surfaced in Step 3 must have a locked answer
+
+### Step 5: Generate Spec
+
+! Derive SPECIFICATION.md tasks from the now-stable test scenarios and locked decisions.
+
+- ! Each scenario maps to one or more spec tasks with traceability (`traces: scenario-N`)
+- ! Locked decisions from `{feature}-bdd-context.md` flow into the spec as constraints
+- ~ Use the Light or Full path from [strategies/interview.md](./interview.md) based on project size
+
+### Step 6: Chain into Interview Sizing Gate
+
+! Follow [strategies/interview.md](./interview.md) sizing gate for SPECIFICATION.md finalisation.
+
+- ! On completion, register artifacts in `./vbrief/plan.vbrief.json`:
+  - Update `completedStrategies`: increment `runCount` for `"bdd"`, append artifact paths
+  - Append all new artifact paths to the flat `artifacts` array
+- ! Return to [interview.md Chaining Gate](./interview.md#chaining-gate)
+- ! The locked decisions from `{feature}-bdd-context.md` and the acceptance tests MUST flow into subsequent strategies and spec generation
+
+---
+
+## Output Artifacts
+
+- `specs/{feature}/acceptance-tests/` -- executable test files derived from Given/When/Then scenarios
+- `{feature}-bdd-context.md` -- locked decisions surfaced by test failures (same format as discuss strategy's context.md)
+
+---
+
+## Fits into Chaining Gate
+
+BDD is a **preparatory** strategy. It can be combined with other preparatory strategies (research, discuss, map) before spec generation. On completion, the chaining gate reappears so the user can run additional strategies or proceed to specification.
+
+⊗ End the session after BDD without returning to the chaining gate.
+
+---
+
+## Anti-Patterns
+
+- ⊗ Writing implementation before acceptance tests -- tests must come first
+- ⊗ Writing acceptance tests that pass immediately -- a passing test before implementation indicates a wrong test or pre-existing feature
+- ⊗ Leaving ambiguities unresolved after Step 3 -- every surfaced question must be locked in Step 4
+- ⊗ Skipping the context.md file -- decisions that exist only in conversation history will be lost
+- ⊗ Writing scenarios with vague placeholders instead of concrete values
+- ⊗ Combining multiple behaviours into a single scenario -- one scenario, one behaviour
+- ⊗ Ending after BDD without chaining into specification generation

--- a/tests/content/test_structure.py
+++ b/tests/content/test_structure.py
@@ -163,3 +163,14 @@ def test_strategy_file_exists(filename: str) -> None:
     """Every strategy listed in strategies/README.md must exist on disk."""
     target = _REPO_ROOT / "strategies" / filename
     assert target.exists(), f"Strategy file missing: strategies/{filename}"
+
+
+# ---------------------------------------------------------------------------
+# Explicit assertions for key strategy files
+# ---------------------------------------------------------------------------
+
+def test_bdd_strategy_exists() -> None:
+    """strategies/bdd.md must exist (t2.7.8, #81)."""
+    assert (_REPO_ROOT / "strategies" / "bdd.md").exists(), (
+        "strategies/bdd.md missing — required by t2.7.8"
+    )


### PR DESCRIPTION
## Summary

Two documentation tasks from SPECIFICATION.md Phase 2.7:

### Task A: meta/philosophy.md (t2.7.7, #159) -- Deterministic > Probabilistic design principle
- Created meta/philosophy.md with RFC2119 legend and See also banner
- Documents the principle: prefer deterministic components (fixed commands, schema validators, CI checks, Taskfile tasks) over probabilistic ones (LLM inference) for repeatable actions
- Includes definition, rationale, concrete examples from the Deft framework (Taskfile tasks, spec_validate.py, CI workflows)
- Scope note explicitly defers broad application to Phase 5
- Added reference from contracts/hierarchy.md See also banner

### Task B: strategies/bdd.md (t2.7.8, #81) -- BDD/acceptance-test-first strategy
- Created strategies/bdd.md with RFC2119 legend and See also banner
- 6-step workflow: identify scenarios, write failing tests, surface ambiguity, lock decisions, generate spec, chain into sizing gate
- Output artifacts: specs/{feature}/acceptance-tests/ + {feature}-bdd-context.md
- Integrates as a preparatory strategy in the chaining gate
- Anti-patterns section
- Added bdd.md row to strategies/README.md
- Added 	est_bdd_strategy_exists to 	ests/content/test_structure.py

### Validation
- 	ask check passes: 875 passed, 25 xfailed
- CHANGELOG.md entries added under [Unreleased]

### Files Changed
- meta/philosophy.md (new)
- strategies/bdd.md (new)
- contracts/hierarchy.md (See also link added)
- strategies/README.md (bdd row added)
- 	ests/content/test_structure.py (bdd assertion added)
- CHANGELOG.md (entries added)

Closes #159
Closes #81