### PR TITLE
fix(docs): update --body-file convention to use OS temp directory (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **--body-file convention updated to OS temp directory** (#256, t1.13.2): Updated `scm/github.md` `--body-file` rules to write temp files to the OS temp directory (`$env:TEMP`/`GetTempFileName` on PowerShell, `mktemp`/`$TMPDIR` on Unix) instead of the worktree -- eliminates the `rm` denylist collision that blocks autonomous swarm agents in Warp; added PowerShell and Unix examples; noted no explicit `rm` needed (OS handles cleanup); added `⊗` anti-pattern against writing temp files in the worktree; updated `skills/deft-swarm/SKILL.md` Prompt Template Step 5 with OS temp dir note; added `test_body_file_os_temp_dir_guidance` to `tests/content/test_standards.py`
 - **Deft-swarm Phase 5->6 gate hardening + crash recovery** (#261, #263, t1.13.1): Strengthened Phase 5->6 gate with explicit context-pressure bypass prohibition and structured merge-readiness checklist; added pre-spawn verification gate in Takeover Triggers (wait for lifecycle idle/blocked event before replacing agent); added per-PR sub-agent identity check in Phase 6; documented duplicate-tab failure mode (root cause of tool_use/tool_result corruption); added context-length warning for long monitoring sessions; added Crash Recovery section with idempotent pre-checks and gh-based state reconstruction; added 2 new anti-patterns; added companion meta/lessons.md entries; added 7 test_skills.py coverage tests
 
 ### Changed

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -977,7 +977,12 @@ Strengthen the Phase 5->6 confirmation gate against context-pressure bypass and 
 
 Update `scm/github.md` to instruct agents to write `--body-file` temp files to the OS temp directory instead of the worktree, eliminating the `rm` denylist collision that blocks autonomous swarm agents.
 
-- <first acceptance criterion placeholder>
+- scm/github.md --body-file convention updated: write temp files to OS temp directory, not the worktree
+- scm/github.md includes PowerShell example using [System.IO.Path]::GetTempFileName() or Join-Path $env:TEMP "pr-body.md"
+- scm/github.md includes Unix example using mktemp or $TMPDIR
+- scm/github.md notes no explicit rm needed -- OS handles cleanup, eliminates rm denylist collision in Warp autonomous agents
+- skills/deft-swarm/SKILL.md Prompt Template Step 5 references OS temp directory pattern for --body-file
+- tests/content/test_standards.py covers OS temp dir guidance presence in scm/github.md
 
 **Traces**: #256
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -973,7 +973,7 @@ Strengthen the Phase 5->6 confirmation gate against context-pressure bypass and 
 
 **Traces**: #261, #263
 
-## t1.13.2: Update --body-file convention to use system temp directory (#256)  `[pending]`
+## t1.13.2: Update --body-file convention to use system temp directory (#256)  `[completed]`
 
 Update `scm/github.md` to instruct agents to write `--body-file` temp files to the OS temp directory instead of the worktree, eliminating the `rm` denylist collision that blocks autonomous swarm agents.
 

--- a/scm/github.md
+++ b/scm/github.md
@@ -11,12 +11,27 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 Rules that apply to every `gh` invocation, regardless of context.
 
 - ! Use `--body-file` for PR and issue bodies longer than one line -- inline `--body` strings break on special characters, newlines, and shell escaping across platforms
+- ! Write `--body-file` temp files to the OS temp directory, not the worktree -- writing temp files inside the worktree triggers `rm` denylist collisions that block autonomous swarm agents in Warp (the agent cannot delete files via `rm` in autonomous mode)
+  - **PowerShell:**
+    ```powershell
+    $bodyFile = [System.IO.Path]::GetTempFileName()
+    [System.IO.File]::WriteAllText($bodyFile, $content, [System.Text.UTF8Encoding]::new($false))
+    gh pr create --title "feat: example" --body-file $bodyFile
+    ```
+  - **Unix (bash/zsh):**
+    ```bash
+    bodyFile=$(mktemp)
+    echo "$content" > "$bodyFile"
+    gh pr create --title "feat: example" --body-file "$bodyFile"
+    ```
+  - No explicit `rm` is needed after `gh pr create` -- the OS handles temp file cleanup automatically. This is the key advantage: it eliminates the `rm` step that collides with the Warp autonomous agent `rm` denylist.
 - ! Immediately verify after every create or edit operation:
   - After `gh pr create`: run `gh pr view <number>` to confirm title, body, and labels rendered correctly
   - After `gh issue create`: run `gh issue view <number>` to confirm body content
   - After `gh pr edit`: re-fetch and verify the edited field
 - ~ Prefer `gh api` for structured/programmatic queries (filtering, bulk reads, JSON output) and `gh pr`/`gh issue` for quick ad-hoc commands
 - ⊗ Construct multi-line `--body` strings inline in shell commands -- always write to a temp file and use `--body-file`
+- ⊗ Write `--body-file` temp files inside the worktree or repository directory -- always use the OS temp directory (`$env:TEMP` on PowerShell, `$TMPDIR` or `/tmp` on Unix)
 
 ## PR Workflow Conventions
 

--- a/scm/github.md
+++ b/scm/github.md
@@ -24,7 +24,7 @@ Rules that apply to every `gh` invocation, regardless of context.
     echo "$content" > "$bodyFile"
     gh pr create --title "feat: example" --body-file "$bodyFile"
     ```
-  - No explicit `rm` is needed after `gh pr create` -- the OS handles temp file cleanup automatically. This is the key advantage: it eliminates the `rm` step that collides with the Warp autonomous agent `rm` denylist.
+  - No explicit `rm` is needed after `gh pr create` -- the file lives outside the worktree, which is the key advantage: it eliminates the `rm` step that collides with the Warp autonomous agent `rm` denylist. (OS temp directories are eventually cleaned by the OS on Unix/macOS; on Windows they persist until manually purged, but agent cleanup is not required.)
 - ! Immediately verify after every create or edit operation:
   - After `gh pr create`: run `gh pr view <number>` to confirm title, body, and labels rendered correctly
   - After `gh issue create`: run `gh issue view <number>` to confirm body content

--- a/skills/deft-swarm/SKILL.md
+++ b/skills/deft-swarm/SKILL.md
@@ -379,6 +379,8 @@ STEP 4 — Commit: Add CHANGELOG.md entries under [Unreleased].
 Commit with message: [type]([scope]): [description] — with bullet-point body.
 
 STEP 5 — Push and PR: Push branch to origin. Create PR targeting master using gh CLI.
+Note: --body-file must use a temp file in the OS temp directory ($env:TEMP on PowerShell,
+$TMPDIR or /tmp on Unix) -- do NOT write temp files in the worktree. See scm/github.md.
 
 STEP 6 — Review cycle: Follow skills/deft-review-cycle/SKILL.md to run the
 Greptile review cycle on the PR. Do NOT merge — leave for human review.

--- a/tests/content/test_standards.py
+++ b/tests/content/test_standards.py
@@ -202,3 +202,21 @@ def test_no_warping_references(rel_path: str) -> None:
         f"{rel_path}: contains deprecated name 'warping' "
         "(project was renamed to Deft — update all references)"
     )
+
+
+# ---------------------------------------------------------------------------
+# 4. OS temp directory guidance for --body-file in scm/github.md
+# ---------------------------------------------------------------------------
+
+
+def test_body_file_os_temp_dir_guidance() -> None:
+    """scm/github.md must contain OS temp directory guidance for --body-file."""
+    text = (_REPO_ROOT / "scm/github.md").read_text(encoding="utf-8", errors="replace")
+    assert "GetTempFileName" in text, (
+        "scm/github.md: missing PowerShell OS temp dir pattern "
+        "(expected GetTempFileName for --body-file guidance)"
+    )
+    assert "mktemp" in text, (
+        "scm/github.md: missing Unix OS temp dir pattern "
+        "(expected mktemp for --body-file guidance)"
+    )


### PR DESCRIPTION
## Summary
Update `scm/github.md` `--body-file` convention to write temp files to the OS temp directory instead of the worktree. This eliminates the `rm` denylist collision that blocks autonomous swarm agents in Warp.

## Changes
- **scm/github.md**: Added `!` rule requiring `--body-file` temp files in OS temp dir; PowerShell (`GetTempFileName`) and Unix (`mktemp`) examples; no explicit `rm` needed (OS handles cleanup); added `anti-pattern` against writing temp files in the worktree
- **skills/deft-swarm/SKILL.md**: Prompt Template Step 5 note referencing OS temp dir pattern
- **tests/content/test_standards.py**: `test_body_file_os_temp_dir_guidance` covering PS + Unix patterns
- **SPECIFICATION.md**: t1.13.2 acceptance criteria filled in
- **CHANGELOG.md**: Entry under [Unreleased]

Closes #256
Spec task: t1.13.2

---
*This PR body was written to a temp file in `c:\temp` -- practicing the convention it implements.*