### PR TITLE
feat(skill): add deft_version field to deft-setup artifact templates (#270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **deft-setup USER.md/PROJECT.md versioning** (#270, t3.2.1): Added `deft_version` field to USER.md and PROJECT.md templates in `skills/deft-setup/SKILL.md`; added USER.md Freshness Detection subsection -- detects stale USER.md via missing or outdated `deft_version`, queries missing fields individually without re-running full interview, writes current version after migration; added `!` rule requiring `deft_version` on every generate/update and anti-pattern against omitting it; added 4 tests to `tests/content/test_skills.py`
 
 ### Fixed
 - **--body-file convention updated to OS temp directory** (#256, t1.13.2): Updated `scm/github.md` `--body-file` rules to write temp files to the OS temp directory (`$env:TEMP`/`GetTempFileName` on PowerShell, `mktemp`/`$TMPDIR` on Unix) instead of the worktree -- eliminates the `rm` denylist collision that blocks autonomous swarm agents in Warp; added PowerShell and Unix examples; noted no explicit `rm` needed (OS handles cleanup); added `⊗` anti-pattern against writing temp files in the worktree; updated `skills/deft-swarm/SKILL.md` Prompt Template Step 5 with OS temp dir note; added `test_body_file_os_temp_dir_guidance` to `tests/content/test_standards.py`

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -685,7 +685,7 @@ Create skills/deft-rwldl/SKILL.md with RFC2119 legend and frontmatter. Structure
 
 **Traces**: #182
 
-## t3.2.1: Validate USER.md against current schema + artifact format versioning (#270)  `[pending]`
+## t3.2.1: Validate USER.md against current schema + artifact format versioning (#270)  `[completed]`
 
 Add a `deft_version` field to all Deft-generated artifact templates (USER.md, PROJECT.md, etc.). When deft-setup or CLI bootstrap finds an existing USER.md, validate it against the current expected field set using the version field. If fields are missing, query the user for missing fields only (do not re-run full interview). Targeted subset of #78.
 

--- a/skills/deft-setup/SKILL.md
+++ b/skills/deft-setup/SKILL.md
@@ -95,7 +95,7 @@ Python, R, Rust, SQL, Swift, TypeScript, VHDL, Visual Basic, Zig, 6502-DASM
 1. ! If `deft_version` is **missing**: the USER.md predates versioning -- treat as stale
 2. ! If `deft_version` is present but **differs from the current framework version** (0.15.0): check whether any expected fields are missing from the USER.md
 3. ! If fields are missing: query the user for each missing field individually -- do NOT re-run the full Phase 1 interview
-4. ! After updating any missing fields, write the current `deft_version` (0.15.0) to USER.md
+4. ! After completing any field queries (even if none were needed), write the current `deft_version` (0.15.0) to USER.md
 5. ~ If `deft_version` matches the current version and all expected fields are present: no action needed (USER.md is fresh)
 
 Expected USER.md fields: **Name**, **Custom Rules**, **Default Strategy**, and optionally **Coverage** and **Experimental Rules**.

--- a/skills/deft-setup/SKILL.md
+++ b/skills/deft-setup/SKILL.md
@@ -88,6 +88,20 @@ Python, R, Rust, SQL, Swift, TypeScript, VHDL, Visual Basic, Zig, 6502-DASM
 - ~ Skip if USER.md exists at the platform-appropriate path (see Platform Detection) and user doesn't want to overwrite
 - ⊗ Scan filesystem beyond checking that one path
 
+### USER.md Freshness Detection
+
+! When an existing USER.md is found (returning user), check its `deft_version` field before skipping Phase 1:
+
+1. ! If `deft_version` is **missing**: the USER.md predates versioning -- treat as stale
+2. ! If `deft_version` is present but **differs from the current framework version** (0.15.0): check whether any expected fields are missing from the USER.md
+3. ! If fields are missing: query the user for each missing field individually -- do NOT re-run the full Phase 1 interview
+4. ! After updating any missing fields, write the current `deft_version` (0.15.0) to USER.md
+5. ~ If `deft_version` matches the current version and all expected fields are present: no action needed (USER.md is fresh)
+
+Expected USER.md fields: **Name**, **Custom Rules**, **Default Strategy**, and optionally **Coverage** and **Experimental Rules**.
+
+⊗ Re-run the full Phase 1 interview when only individual fields are missing from a stale USER.md -- query missing fields individually instead.
+
 ### Interview Rules
 
 ! **Each message you send MUST contain exactly ONE question.** This is the most
@@ -150,6 +164,8 @@ Resolve using Platform Detection above. Write to the platform-appropriate path
 # User Preferences
 
 Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+**deft_version**: 0.15.0
 
 ## Personal (always wins)
 
@@ -284,6 +300,8 @@ apply here too. Do not combine questions.
 # {Project Name} Project Guidelines
 
 Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
+
+**deft_version**: 0.15.0
 
 Only specify items here that **override or extend** the deft defaults.
 
@@ -491,6 +509,8 @@ Per [strategies/interview.md](../../strategies/interview.md#interview-rules-shar
 
 ## Anti-Patterns
 
+- ! When deft-setup generates or updates USER.md or PROJECT.md, the `deft_version` field MUST be set to the current framework version
+- ⊗ Generate a USER.md or PROJECT.md without including the `deft_version` field
 - ⊗ Explore codebase before Phase 1 questions
 - ⊗ Read framework files before first question
 - ⊗ Batch multiple questions into one message — ask one at a time, interview style

--- a/tests/content/test_skills.py
+++ b/tests/content/test_skills.py
@@ -904,3 +904,59 @@ def test_deft_swarm_antipattern_no_skip_phase5_gate() -> None:
         f"{_SWARM_PATH}: missing anti-pattern against skipping "
         "Phase 5 gate under pressure (#261, t1.13.1)"
     )
+
+
+# ---------------------------------------------------------------------------
+# 29. deft-setup USER.md/PROJECT.md deft_version field (#270, t3.2.1)
+# ---------------------------------------------------------------------------
+
+_SETUP_PATH = "skills/deft-setup/SKILL.md"
+
+
+def test_deft_setup_user_md_template_has_deft_version() -> None:
+    """USER.md template in deft-setup must contain a deft_version field."""
+    text = _read_skill(_SETUP_PATH)
+    # The template is inside a ```markdown code block in Phase 1
+    assert "**deft_version**:" in text, (
+        f"{_SETUP_PATH}: USER.md template must include a deft_version field (#270, t3.2.1)"
+    )
+
+
+def test_deft_setup_project_md_template_has_deft_version() -> None:
+    """PROJECT.md template in deft-setup must contain a deft_version field."""
+    text = _read_skill(_SETUP_PATH)
+    # Both USER.md and PROJECT.md templates should have deft_version;
+    # verify at least two occurrences (one per template)
+    count = text.count("**deft_version**:")
+    assert count >= 2, (
+        f"{_SETUP_PATH}: both USER.md and PROJECT.md templates must include "
+        f"deft_version field -- found {count} occurrence(s), expected >= 2 (#270, t3.2.1)"
+    )
+
+
+def test_deft_setup_stale_user_md_detection() -> None:
+    """deft-setup must contain stale USER.md detection via deft_version field."""
+    text = _read_skill(_SETUP_PATH)
+    lower = text.lower()
+    assert "freshness detection" in lower, (
+        f"{_SETUP_PATH}: must contain USER.md Freshness Detection section (#270, t3.2.1)"
+    )
+    assert "predates versioning" in lower and "treat as stale" in lower, (
+        f"{_SETUP_PATH}: must detect missing deft_version as stale (#270, t3.2.1)"
+    )
+    assert "query missing fields individually" in lower, (
+        f"{_SETUP_PATH}: must query missing fields individually, "
+        "not re-run full interview (#270, t3.2.1)"
+    )
+
+
+def test_deft_setup_deft_version_must_rule() -> None:
+    """deft-setup must have a ! rule requiring deft_version on generate/update."""
+    text = _read_skill(_SETUP_PATH)
+    assert "deft_version` field MUST be set" in text, (
+        f"{_SETUP_PATH}: must have ! rule requiring deft_version field "
+        "when generating or updating USER.md/PROJECT.md (#270, t3.2.1)"
+    )
+    assert "\u2297" in text and "without including the `deft_version` field" in text, (
+        f"{_SETUP_PATH}: must have \u2297 anti-pattern against omitting deft_version (#270, t3.2.1)"
+    )


### PR DESCRIPTION
## Summary

Add `deft_version` field to deft-setup artifact templates (USER.md and PROJECT.md) and implement stale USER.md detection via version field comparison.

Implements spec task **t3.2.1** -- Validate USER.md against current schema + artifact format versioning (#270).

## Changes

### skills/deft-setup/SKILL.md
- **Change 1**: USER.md template (Phase 1) now includes `**deft_version**: 0.15.0` after the legend line
- **Change 2**: PROJECT.md template (Phase 2) now includes `**deft_version**: 0.15.0` after the legend line
- **Change 3**: New `### USER.md Freshness Detection` subsection -- detects stale USER.md via missing/outdated `deft_version`, queries missing fields individually (no full re-interview), writes current version after migration
- **Change 4**: New `!` rule in Anti-Patterns requiring `deft_version` on every generate/update; corresponding anti-pattern against omitting it

### tests/content/test_skills.py
- 4 new tests: USER.md template deft_version, PROJECT.md template deft_version, stale detection guidance, `!` rule for deft_version

### SPECIFICATION.md
- t3.2.1 status updated from `[pending]` to `[completed]`

### CHANGELOG.md
- Entry added under `[Unreleased]`

## Checklist
- [x] SPECIFICATION.md has task coverage (t3.2.1)
- [x] CHANGELOG.md entry under [Unreleased]
- [x] `task check` passes (95/95 skill tests pass; pre-existing Windows teardown issue unrelated)
- [x] Feature branch (not direct to master)
- [x] /deft:change N/A (fewer than 3 files of substance changed)

Closes #270