### PR TITLE
feat(tasks): add changelog:check, change:init, and commit:lint tasks (#233, #235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Toolchain verification task** (#233, #235, t3.3.2): Created `tasks/toolchain.yml` with `toolchain:check` task and `scripts/toolchain-check.py` -- verifies go, uv, task, git, gh are installed; wired as dep of enhanced `check` task
 - **Code verification tasks** (#235, t3.3.2): Created `tasks/verify.yml` with `verify:stubs` (scans .py/.go/.sh for TODO/FIXME/HACK/stub patterns via `scripts/verify-stubs.py`) and `verify:links` (checks .md internal link targets via `scripts/validate-links.py`, warning mode for pre-existing broken links, `--strict` flag or `LINK_CHECK_STRICT=1` for strict mode); both wired as deps of enhanced `check` task
 - **Spec tasks t3.3.1 and t3.3.2** added to `SPECIFICATION.md` for Taskfile restructure and verification tasks
+- **changelog:check, change:init, and commit:lint tasks** (#233, #235, t3.3.3): Created `tasks/change.yml` with `changelog:check` (verifies CHANGELOG.md [Unreleased] section has at least one entry, exits non-zero if missing) and `change:init` (scaffolds `history/changes/<name>/` with proposal.md, design.md, tasks.vbrief.json, and specs/ subdirectory per commands.md templates). Created `tasks/commit.yml` with `commit:lint` (validates HEAD commit message against conventional commit format -- type(scope): description; accepted types: feat, fix, docs, chore, refactor, test, style, perf, ci, build; exits non-zero on violation). Both task files are standalone with `version: '3'` for independent testability.
 
 ## [0.16.0] - 2026-04-10
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1146,5 +1146,15 @@ Create tasks/toolchain.yml with toolchain:check (reads PROJECT.md for declared t
 - validate:links checks .md internal link targets exist
 - Enhanced check includes toolchain:check, verify:stubs, validate:links as deps
 - task check passes
+## t3.3.3: Add changelog:check, change:init, and commit:lint tasks (#233, #235)  `[pending]`
+
+Create tasks/change.yml with changelog:check (verify CHANGELOG.md has an [Unreleased] section with at least one entry since the last release tag; exit non-zero if missing) and change:init (takes a name via CLI_ARGS, creates history/changes/<name>/ directory with proposal.md, design.md, tasks.vbrief.json, and specs/ subdirectory using deterministic templates per commands.md). Create tasks/commit.yml with commit:lint (validate HEAD commit message against conventional commit format -- type(scope): description; accepted types: feat, fix, docs, chore, refactor, test, style, perf, ci, build; exit non-zero on violation).
+
+- tasks/change.yml exists with changelog:check and change:init tasks
+- tasks/commit.yml exists with commit:lint task
+- changelog:check verifies [Unreleased] section has entries
+- change:init creates correct directory structure per commands.md
+- commit:lint validates conventional commit format
+- All tasks exit non-zero on failure
 
 **Traces**: #233, #235

--- a/tasks/change.yml
+++ b/tasks/change.yml
@@ -24,9 +24,10 @@ tasks:
     cmds:
       - cmd: >-
           uv run python -c
-          "import sys, pathlib, json;
+          "import sys, pathlib, json, re;
           name = '{{.CLI_ARGS}}'.strip();
           (not name) and (print('FAIL: Usage: task change:init -- <name>'), sys.exit(1));
+          (not re.match(r'^[\w][\w-]*$', name)) and (print('FAIL: Name must contain only alphanumeric characters, underscores, and hyphens'), sys.exit(1));
           base = pathlib.Path('history/changes') / name;
           base.exists() and (print(f'FAIL: {base} already exists'), sys.exit(1));
           (base / 'specs').mkdir(parents=True, exist_ok=True);

--- a/tasks/change.yml
+++ b/tasks/change.yml
@@ -1,0 +1,38 @@
+version: '3'
+
+tasks:
+  changelog:check:
+    desc: Verify CHANGELOG.md has an [Unreleased] section with at least one entry
+    env:
+      PYTHONUTF8: "1"
+    cmds:
+      - cmd: >-
+          uv run python -c
+          "import sys, pathlib, re;
+          p = pathlib.Path('CHANGELOG.md');
+          (not p.exists()) and (print('FAIL: CHANGELOG.md not found'), sys.exit(1));
+          text = p.read_text('utf-8');
+          m = re.search(r'## \[Unreleased\][ \t]*\n(.*?)(?=\n## \[|$)', text, re.DOTALL);
+          (m is None) and (print('FAIL: No [Unreleased] section found in CHANGELOG.md'), sys.exit(1));
+          body = m.group(1);
+          entries = [l for l in body.splitlines() if l.strip().startswith('- ')];
+          (len(entries) == 0) and (print('FAIL: [Unreleased] section has no entries (no lines starting with \"- \")'), sys.exit(1));
+          print(f'OK: CHANGELOG.md [Unreleased] section has {len(entries)} entries')"
+
+  change:init:
+    desc: Create a new change proposal directory structure in history/changes/<name>/
+    cmds:
+      - cmd: >-
+          uv run python -c
+          "import sys, pathlib, json;
+          name = '{{.CLI_ARGS}}'.strip();
+          (not name) and (print('FAIL: Usage: task change:init -- <name>'), sys.exit(1));
+          base = pathlib.Path('history/changes') / name;
+          base.exists() and (print(f'FAIL: {base} already exists'), sys.exit(1));
+          (base / 'specs').mkdir(parents=True, exist_ok=True);
+          (base / 'proposal.md').write_text('# ' + name + chr(10) + chr(10) + '## Problem' + chr(10) + chr(10) + 'What is wrong or missing.' + chr(10) + chr(10) + '## Change' + chr(10) + chr(10) + 'What this proposal does about it.' + chr(10) + chr(10) + '## Scope' + chr(10) + chr(10) + '**In scope:**' + chr(10) + '- ' + chr(10) + chr(10) + '**Out of scope:**' + chr(10) + '- ' + chr(10) + chr(10) + '## Impact' + chr(10) + chr(10) + 'What existing code/specs are affected.' + chr(10) + chr(10) + '## Risks' + chr(10) + chr(10) + 'What could go wrong.' + chr(10), encoding='utf-8');
+          (base / 'design.md').write_text('# ' + name + ' -- Design' + chr(10) + chr(10) + '## Approach' + chr(10) + chr(10) + 'How to implement the change.' + chr(10) + chr(10) + '## Alternatives' + chr(10) + chr(10) + 'What else was considered and why not.' + chr(10) + chr(10) + '## Dependencies' + chr(10) + chr(10) + 'What must exist before this works.' + chr(10), encoding='utf-8');
+          vbrief = {'vBRIEFInfo': {'version': '0.5'}, 'plan': {'title': name, 'status': 'draft', 'items': [], 'edges': []}};
+          (base / 'tasks.vbrief.json').write_text(json.dumps(vbrief, indent=2) + chr(10), encoding='utf-8');
+          print(f'OK: Created change proposal at {base}/');
+          [print(f'  - {f}') for f in ['proposal.md', 'design.md', 'tasks.vbrief.json', 'specs/']]"

--- a/tasks/commit.yml
+++ b/tasks/commit.yml
@@ -11,8 +11,8 @@ tasks:
           (result.returncode != 0) and (print('FAIL: Could not read HEAD commit message'), sys.exit(1));
           msg = result.stdout.strip();
           subject = msg.splitlines()[0] if msg else '';
-          types = 'feat|fix|docs|chore|refactor|test|style|perf|ci|build';
-          pattern = r'^(' + types + r')(\(.+\))?: .+';
+          types = 'feat|fix|docs|chore|refactor|test|style|perf|ci|build|revert';
+          pattern = r'^(' + types + r')(\(.+\))?!?: .+';
           ok = re.match(pattern, subject);
           (not ok) and (print('FAIL: Commit message does not match conventional commit format'),
           print(f'  Got:      {subject}'),

--- a/tasks/commit.yml
+++ b/tasks/commit.yml
@@ -17,7 +17,7 @@ tasks:
           (not ok) and (print('FAIL: Commit message does not match conventional commit format'),
           print(f'  Got:      {subject}'),
           print(f'  Expected: type(scope): description'),
-          print(f'  Types:    feat, fix, docs, chore, refactor, test, style, perf, ci, build'),
+          print(f'  Types:    feat, fix, docs, chore, refactor, test, style, perf, ci, build, revert'),
           sys.exit(1));
           print(f'OK: Commit message is valid conventional commit');
           print(f'  Subject: {subject}')"

--- a/tasks/commit.yml
+++ b/tasks/commit.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+tasks:
+  commit:lint:
+    desc: Validate HEAD commit message against conventional commit format
+    cmds:
+      - cmd: >-
+          uv run python -c
+          "import sys, re, subprocess;
+          result = subprocess.run(['git', 'log', '--format=%B', '-1'], capture_output=True, text=True);
+          (result.returncode != 0) and (print('FAIL: Could not read HEAD commit message'), sys.exit(1));
+          msg = result.stdout.strip();
+          subject = msg.splitlines()[0] if msg else '';
+          types = 'feat|fix|docs|chore|refactor|test|style|perf|ci|build';
+          pattern = r'^(' + types + r')(\(.+\))?: .+';
+          ok = re.match(pattern, subject);
+          (not ok) and (print('FAIL: Commit message does not match conventional commit format'),
+          print(f'  Got:      {subject}'),
+          print(f'  Expected: type(scope): description'),
+          print(f'  Types:    feat, fix, docs, chore, refactor, test, style, perf, ci, build'),
+          sys.exit(1));
+          print(f'OK: Commit message is valid conventional commit');
+          print(f'  Subject: {subject}')"


### PR DESCRIPTION
## Summary

Add deterministic task files for change lifecycle management and commit validation.

### Changes

- **tasks/change.yml**: changelog:check (verifies CHANGELOG.md [Unreleased] section has entries) and change:init (scaffolds history/changes/<name>/ with proposal.md, design.md, tasks.vbrief.json, specs/ per commands.md)
- **tasks/commit.yml**: commit:lint (validates HEAD commit against conventional commit format -- type(scope): description)
- **SPECIFICATION.md**: Added spec task t3.3.3
- **CHANGELOG.md**: Entry under [Unreleased]

### Testing

- All three tasks validated standalone with `task --taskfile`:
  - `changelog:check` correctly fails on empty [Unreleased], passes with entries
  - `change:init` creates correct directory structure with valid vBRIEF JSON
  - `commit:lint` validates conventional commit format
- `task check` passes (985 tests, 0 failures)

### Checklist

- [x] SPECIFICATION.md has task coverage (t3.3.3)
- [x] CHANGELOG.md entry under [Unreleased]
- [x] `task check` passes
- [x] Conventional commit message
- [x] Feature branch (not direct to master)

Closes #233, Closes #235