### PR TITLE
docs(roadmap): refresh -- add #298 to Phase 1 Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Roadmap Refresh (2026-04-12)**: Triaged 1 new issue -- #298 (Phase 1 Cleanup: flip 5 stale `[pending]` spec task statuses to `[completed]` in SPECIFICATION.md -- t1.14.1, t1.15.1, t1.18.1, t1.19.1, t1.20.1 -- shipped v0.16.0 but SPECIFICATION.md not synced, t1.25.1); no stale entries; analysis comment posted on #298
 
-## [0.18.0]
+## [0.18.0] - 2026-04-10
 
 ### Added
 - **skills/deft-interview/SKILL.md -- deterministic structured Q&A interview skill** (#296, t2.11.1): Created `skills/deft-interview/SKILL.md` with RFC2119 legend and YAML frontmatter encoding a deterministic interview loop any skill can invoke -- 7 rules: one-question-per-turn, numbered options with stated default (`[default: N]`), explicit other/IDK escape option, depth gate, default-acceptance, confirmation gate, and structured handoff contract (answers map); created `.agents/skills/deft-interview/SKILL.md` thin pointer; added AGENTS.md Skill Routing entry; updated deft-setup Phase 1 and Phase 2 to reference deft-interview; added 12 tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.18.0] - 2026-04-10
+### Changed
+- **Roadmap Refresh (2026-04-12)**: Triaged 1 new issue -- #298 (Phase 1 Cleanup: flip 5 stale `[pending]` spec task statuses to `[completed]` in SPECIFICATION.md -- t1.14.1, t1.15.1, t1.18.1, t1.19.1, t1.20.1 -- shipped v0.16.0 but SPECIFICATION.md not synced, t1.25.1); no stale entries; analysis comment posted on #298
+
+## [0.18.0]
 
 ### Added
 - **skills/deft-interview/SKILL.md -- deterministic structured Q&A interview skill** (#296, t2.11.1): Created `skills/deft-interview/SKILL.md` with RFC2119 legend and YAML frontmatter encoding a deterministic interview loop any skill can invoke -- 7 rules: one-question-per-turn, numbered options with stated default (`[default: N]`), explicit other/IDK escape option, depth gate, default-acceptance, confirmation gate, and structured handoff contract (answers map); created `.agents/skills/deft-interview/SKILL.md` thin pointer; added AGENTS.md Skill Routing entry; updated deft-setup Phase 1 and Phase 2 to reference deft-interview; added 12 tests

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ Fix reported bugs and UX problems blocking adoption.
 
 ### Cleanup
 
-(all resolved -- v0.18.0)
+- **#298** -- Flip 5 stale `[pending]` task statuses to `[completed]` in SPECIFICATION.md (t1.14.1, t1.15.1, t1.18.1, t1.19.1, t1.20.1)
 
 ---
 
@@ -411,7 +411,8 @@ Larger feature work -- only after issues are resolved and content is stable.
 | #293 | test: add unit tests for v0.17.0 deterministic task scripts | 3 |
 | ~~#294~~ | ~~fix(enforcement): strengthen test-with-code rule -- new source files must include tests~~ | completed -- v0.18.0 |
 | ~~#295~~ | ~~chore: resolve 5 untracked xfail gaps in known_failures.json~~ | completed -- v0.18.0 |
-| ~~#296~~ | ~~Create skills/deft-interview/SKILL.md -- deterministic structured Q&A interview skill~~ | completed -- v0.18.0 |
+|| ~~#296~~ | ~~Create skills/deft-interview/SKILL.md -- deterministic structured Q&A interview skill~~ | completed -- v0.18.0 |
+|| #298 | chore(spec): flip 5 stale [pending] statuses to [completed] in SPECIFICATION.md | 1 |
 
 ---
 
@@ -479,3 +480,4 @@ Larger feature work -- only after issues are resolved and content is stable.
 *Updated 2026-04-10 -- roadmap refresh triage: added #295 (Phase 1 Cleanup, t1.24.1): resolve 5 untracked xfail gaps in known_failures.json; analysis comment posted*
 *Updated 2026-04-10 -- roadmap refresh triage: added #296 (Phase 2, t2.11.1): skills/deft-interview/SKILL.md -- deterministic structured Q&A interview skill; analysis comment posted*
 *Updated 2026-04-10 -- v0.18.0 release: moved #288, #292, #294, #295 (Phase 1 Cleanup), #296 (Phase 2) to Completed; struck through in Open Issues Index; Phase 1 Cleanup now empty*
+*Updated 2026-04-12 -- roadmap refresh triage: added #298 (Phase 1 Cleanup, t1.25.1): flip 5 stale [pending] spec task statuses to [completed] in SPECIFICATION.md (t1.14.1, t1.15.1, t1.18.1, t1.19.1, t1.20.1); analysis comment posted*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -411,8 +411,8 @@ Larger feature work -- only after issues are resolved and content is stable.
 | #293 | test: add unit tests for v0.17.0 deterministic task scripts | 3 |
 | ~~#294~~ | ~~fix(enforcement): strengthen test-with-code rule -- new source files must include tests~~ | completed -- v0.18.0 |
 | ~~#295~~ | ~~chore: resolve 5 untracked xfail gaps in known_failures.json~~ | completed -- v0.18.0 |
-|| ~~#296~~ | ~~Create skills/deft-interview/SKILL.md -- deterministic structured Q&A interview skill~~ | completed -- v0.18.0 |
-|| #298 | chore(spec): flip 5 stale [pending] statuses to [completed] in SPECIFICATION.md | 1 |
+| ~~#296~~ | ~~Create skills/deft-interview/SKILL.md -- deterministic structured Q&A interview skill~~ | completed -- v0.18.0 |
+| #298 | chore(spec): flip 5 stale [pending] statuses to [completed] in SPECIFICATION.md | 1 |
 
 ---
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1223,3 +1223,11 @@ Add tests/cli/test_task_scripts.py with subprocess-based unit tests for all scri
 - <first acceptance criterion placeholder>
 
 **Traces**: #293
+
+## t1.25.1: Flip 5 stale [pending] spec task statuses to [completed] in SPECIFICATION.md (#298)  `[pending]`
+
+SPECIFICATION.md has 5 spec tasks showing `[pending]` status that were completed and shipped in v0.16.0. Flip t1.14.1, t1.15.1, t1.18.1, t1.19.1, and t1.20.1 from `[pending]` to `[completed]` to sync SPECIFICATION.md with ROADMAP.md and CHANGELOG.md.
+
+- <first acceptance criterion placeholder>
+
+**Traces**: #298


### PR DESCRIPTION
## Summary

Roadmap refresh session (2026-04-12): triaged 1 new issue into the phased roadmap.

## Related Issues

Triaged (not closing -- these are open work items):
- #298 -- Phase 1 Cleanup: flip 5 stale `[pending]` spec task statuses to `[completed]`

## Checklist

- [x] `/deft:change <name>` -- N/A (doc-only, <3 files, not cross-cutting)
- [x] `CHANGELOG.md` -- added entry under `[Unreleased]`
- [x] `ROADMAP.md` -- updated with new triage entry and index row
- [x] Tests pass locally (task check: 1028 passed, 2 xfailed)

## Post-Merge

- [ ] **Verify issue auto-close**: N/A -- no closing keywords (triage PR, issues remain open)
- [ ] Enable branch protection on `master` requiring CI status check (one-time setup, see #57)