### PR TITLE
feat(vbrief): update vbrief.md with vBRIEF-centric document model (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **vBRIEF-centric document model in vbrief.md** (#310, Part of #309): Rewrote File Taxonomy section with lifecycle folder structure (proposed/, pending/, active/, completed/, cancelled/), status-to-folder mapping, PROJECT-DEFINITION.vbrief.json type, scope vBRIEF filename convention (YYYY-MM-DD-descriptive-slug.vbrief.json), status-driven moves (plan.status as source of truth), origin provenance requirement, bidirectional epic-story linking, plan.vbrief.json and continue.vbrief.json coexistence with scope vBRIEFs (planRef), scope splitting pattern; added PROJECT-DEFINITION.vbrief.json section; updated plan.vbrief.json and continue.vbrief.json sections with scope vBRIEF references; added 4 new anti-patterns
+
 ## [0.19.0] - 2026-04-13
 
 ### Added

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -10,17 +10,136 @@ Legend (from RFC2119): !=MUST, ~=SHOULD, ≉=SHOULD NOT, ⊗=MUST NOT, ?=MAY.
 
 ## File Taxonomy
 
-All vBRIEF files live in `./vbrief/` within the project workspace. There are exactly 5 types:
+All vBRIEF files live in `./vbrief/` within the project workspace. Files are organized into **singular operational files** at the vbrief root and **scope vBRIEFs** in lifecycle folders.
+
+### Directory Structure
+
+```
+vbrief/
+  PROJECT-DEFINITION.vbrief.json   <- project identity gestalt
+  plan.vbrief.json                 <- session-level tactical plan (singular)
+  continue.vbrief.json             <- interruption checkpoint (singular, ephemeral)
+  playbook-{name}.vbrief.json      <- reusable operational patterns
+  proposed/                         <- ideas, not committed to (draft, proposed)
+  pending/                          <- accepted backlog (approved, pending)
+  active/                           <- in progress (running, blocked)
+  completed/                        <- done (completed)
+  cancelled/                        <- rejected/abandoned (cancelled), restorable
+```
+
+### Singular Files
 
 | File | Purpose | Lifecycle |
-|------|---------|-----------|
+|------|---------|----------|
+| `PROJECT-DEFINITION.vbrief.json` | Project identity gestalt — `narratives` for identity (overview, tech stack, architecture, risks/unknowns, config), `items` as scope registry; uses existing v0.5 schema | Durable (regenerated on demand) |
 | `specification.vbrief.json` | Project spec source of truth | Durable (never deleted) |
-| `specification-{name}.vbrief.json` | Add-on spec, must include `planRef` back to main spec | Durable |
-| `plan.vbrief.json` | Single active work plan; absorbs todo/plan/progress | Session-durable |
-| `continue.vbrief.json` | Interruption recovery checkpoint | Ephemeral (consumed on resume) |
+| `specification-{name}.vbrief.json` | Add-on spec with `planRef` back to main spec | Durable |
+| `plan.vbrief.json` | Session-level tactical plan; the *how right now*; carries `planRef` to scope vBRIEFs | Session-durable |
+| `continue.vbrief.json` | Interruption recovery checkpoint; carries `planRef` to scope vBRIEFs | Ephemeral (consumed on resume) |
 | `playbook-{name}.vbrief.json` | Reusable operational knowledge | Permanent |
 
-- ! All vBRIEF files MUST live in `./vbrief/` — never in workspace root or elsewhere
+### Scope vBRIEFs and Lifecycle Folders
+
+Individual units of work (features, bugs, initiatives) live as scope vBRIEFs in five lifecycle folders:
+
+| Folder | Status Values | Description |
+|--------|---------------|-------------|
+| `proposed/` | `draft`, `proposed` | Ideas and proposals, not yet committed |
+| `pending/` | `approved`, `pending` | Accepted backlog, ready for work |
+| `active/` | `running`, `blocked` | In progress; `blocked` is temporary — stays in `active/` |
+| `completed/` | `completed` | Done — terminal state |
+| `cancelled/` | `cancelled` | Rejected/abandoned — restorable to `proposed/` |
+
+### Status-Driven Moves
+
+- ! `plan.status` inside each scope vBRIEF is the **source of truth** — not the folder location
+- ! Folder location is a convenience view for humans; metadata is authoritative
+- ! Agents MUST move files to the matching lifecycle folder when status changes
+- ~ When folder/status drift is detected, trust the status field and correct the folder
+- ⊗ Move files between folders without updating `plan.status`
+
+### Filename Convention
+
+- ! Scope vBRIEF filenames MUST follow: `YYYY-MM-DD-descriptive-slug.vbrief.json`
+- ! The date MUST be the **creation date** (immutable — does not change as the scope progresses)
+- ~ Use lowercase hyphen-separated slugs (e.g. `2026-04-12-add-oauth-flow.vbrief.json`)
+
+### Origin Provenance
+
+- ! Every ingested scope vBRIEF MUST carry `references` linking to its origin
+- ! Enables deduplication during ingest (diff open issues against existing vBRIEF references)
+- ~ On scope completion, update the origin (close the issue, post a comment linking to the PR)
+
+Reference types (extensible by convention): `github-issue`, `jira-ticket`, `user-request`
+
+```json
+"references": [
+  { "type": "github-issue", "url": "https://github.com/deftai/directive/issues/123", "id": "#123" }
+]
+```
+
+### Epic-Story Linking
+
+Larger initiatives use **epic vBRIEFs** linking to child **story vBRIEFs**. Linking is bidirectional:
+
+- ! Epic `references` array MUST list child story file paths (type: `x-vbrief/plan`)
+- ! Story vBRIEFs MUST carry `planRef` back to their parent epic
+- ~ The decision to create an epic vs. a standalone story is made collaboratively between user and agent
+
+**Epic → Stories** (via `references`):
+```json
+{
+  "plan": {
+    "title": "Auth system overhaul",
+    "status": "running",
+    "references": [
+      { "type": "x-vbrief/plan", "url": "./active/2026-04-12-oauth-flow.vbrief.json" },
+      { "type": "x-vbrief/plan", "url": "./active/2026-04-12-session-mgmt.vbrief.json" }
+    ]
+  }
+}
+```
+
+**Story → Epic** (via `planRef`):
+```json
+{
+  "plan": {
+    "title": "Implement OAuth flow",
+    "status": "running",
+    "planRef": "./active/2026-04-10-auth-system-overhaul.vbrief.json"
+  }
+}
+```
+
+### Coexistence: Scope vBRIEFs, plan.vbrief.json, and continue.vbrief.json
+
+Scope vBRIEFs are durable scope records (the *what*); `plan.vbrief.json` remains the ephemeral session-level tactical plan (the *how right now*); `continue.vbrief.json` remains the interruption checkpoint. Both gain a parent reference to scope vBRIEFs via `planRef`.
+
+- **Scope vBRIEF** — acceptance criteria, scope definition, origin provenance. Durable across sessions. Shared between agents.
+- **plan.vbrief.json** — granular implementation steps for this session. Ephemeral. Agent-private.
+- **continue.vbrief.json** — interruption checkpoint. References scope vBRIEF(s) being worked on.
+
+- ! plan.vbrief.json and continue.vbrief.json MUST carry a `planRef` to the scope vBRIEF(s) they relate to
+- ⊗ Use scope vBRIEFs as session scratchpads — that is what plan.vbrief.json is for
+
+### Scope Splitting
+
+When a scope grows too large, the parent vBRIEF becomes an epic and children are created:
+
+1. Agent identifies the scope is too large (collaboratively with user)
+2. Parent vBRIEF promoted to epic
+3. Child story vBRIEFs created with `planRef` back to parent
+4. Parent epic's `references` updated to list all child paths
+5. Acceptance criteria redistributed by agent with user approval
+6. Origin provenance stays on the parent epic; children inherit via epic relationship
+
+- ! Scope splitting is agent-driven using existing tools — no dedicated split command
+- ! Origin provenance stays on the parent; children inherit via epic relationship
+- ~ Uses existing `scope:*` commands for lifecycle transitions after splitting
+
+### General Rules
+
+- ! All vBRIEF files MUST live in `./vbrief/` or its lifecycle subfolders — never in workspace root
 - ! File names MUST use the `.vbrief.json` extension
 - ⊗ Use ULID or timestamp suffixes on `continue` or `plan` — they are singular by design
 - ⊗ Create multiple `plan.vbrief.json` files — there is exactly one active plan
@@ -184,14 +303,30 @@ The source-of-truth for project intent. Created via the interview process in
 
 ---
 
+## PROJECT-DEFINITION.vbrief.json
+
+The synthesized project identity — what this project IS right now. Uses the existing vBRIEF v0.5 schema:
+
+- `narratives` holds project identity: overview, tech stack, architecture, risks/unknowns, configuration
+- `items` acts as a registry of active scopes, each referencing its individual scope vBRIEF file
+- `plan.status` represents overall project state (e.g. `running`, `draft`)
+
+**Regeneration**: Deterministic tooling updates the items registry from folder contents; agent-assisted layer reviews and proposes narrative updates with user approval.
+
+- ! Singular — exactly one per project at `./vbrief/` root
+- ~ Regenerated on scope completion and callable on demand
+
+---
+
 ## plan.vbrief.json
 
-The single active work plan. Unifies what were previously separate todo, plan, and progress files.
+The single active work plan. Unifies what were previously separate todo, plan, and progress files. When scope vBRIEFs are in use, plan.vbrief.json is the session-level tactical plan (the *how right now*) and carries a `planRef` to the scope vBRIEF(s) being implemented.
 
 **Status lifecycle per task:** `pending` → `running` → `completed` / `blocked` / `cancelled`
 
 - ! There is exactly ONE `plan.vbrief.json` at a time per project
 - ! Use this wherever you would use a Warp `create_todo_list` — externalise to this file instead
+- ! When scope vBRIEFs exist, MUST include `planRef` to the scope vBRIEF(s) being implemented
 - ~ Update task statuses as work progresses
 - ! Mark tasks `blocked` with a narrative explaining the blocker
 - ~ Record blocked ideas with `blocked` status and a narrative explaining why
@@ -246,10 +381,11 @@ tracks which strategies have been run and what artifacts they produced.
 ## continue.vbrief.json
 
 A single interruption-recovery checkpoint. See [resilience/continue-here.md](../resilience/continue-here.md)
-for full protocol.
+for full protocol. When scope vBRIEFs are in use, continue.vbrief.json carries a `planRef` to the scope vBRIEF(s) the agent was working on.
 
 - ! Singular — `continue.vbrief.json`, not `continue-{ULID}.json`
 - ! Ephemeral — consumed on resume; must be deleted (or marked `completed`) afterwards
+- ! When scope vBRIEFs exist, MUST include `planRef` to the scope vBRIEF(s) being worked on
 - ⊗ Accumulate stale continue files
 
 ---
@@ -332,3 +468,7 @@ Add-on specs follow the same flow:
 - ⊗ Editing `SPECIFICATION.md` directly — it is a generated artifact
 - ⊗ Treating `plan.vbrief.json` as a scratch file and deleting it mid-task
 - ⊗ Creating both a `plan.vbrief.json` and a separate `progress.vbrief.json` — they are the same file
+- ⊗ Moving scope vBRIEFs between lifecycle folders without updating `plan.status`
+- ⊗ Using scope vBRIEFs as session scratchpads — use plan.vbrief.json for tactical session work
+- ⊗ Creating scope vBRIEFs without origin provenance (`references` linking to the origin)
+- ⊗ Omitting `planRef` from plan.vbrief.json or continue.vbrief.json when scope vBRIEFs exist

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -17,6 +17,8 @@ All vBRIEF files live in `./vbrief/` within the project workspace. Files are org
 ```
 vbrief/
   PROJECT-DEFINITION.vbrief.json   <- project identity gestalt
+  specification.vbrief.json        <- project spec source of truth
+  specification-{name}.vbrief.json <- add-on specs
   plan.vbrief.json                 <- session-level tactical plan (singular)
   continue.vbrief.json             <- interruption checkpoint (singular, ephemeral)
   playbook-{name}.vbrief.json      <- reusable operational patterns
@@ -27,7 +29,7 @@ vbrief/
   cancelled/                        <- rejected/abandoned (cancelled), restorable
 ```
 
-### Singular Files
+### Root-Level Files
 
 | File | Purpose | Lifecycle |
 |------|---------|----------|
@@ -82,6 +84,7 @@ Reference types (extensible by convention): `github-issue`, `jira-ticket`, `user
 
 Larger initiatives use **epic vBRIEFs** linking to child **story vBRIEFs**. Linking is bidirectional:
 
+- ! All `url` and `planRef` path values in scope vBRIEF JSON are **relative to the `vbrief/` directory** — not relative to the containing file's location
 - ! Epic `references` array MUST list child story file paths (type: `x-vbrief/plan`)
 - ! Story vBRIEFs MUST carry `planRef` back to their parent epic
 - ~ The decision to create an epic vs. a standalone story is made collaboratively between user and agent
@@ -134,7 +137,6 @@ When a scope grows too large, the parent vBRIEF becomes an epic and children are
 6. Origin provenance stays on the parent epic; children inherit via epic relationship
 
 - ! Scope splitting is agent-driven using existing tools — no dedicated split command
-- ! Origin provenance stays on the parent; children inherit via epic relationship
 - ~ Uses existing `scope:*` commands for lifecycle transitions after splitting
 
 ### General Rules

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -119,10 +119,10 @@ Larger initiatives use **epic vBRIEFs** linking to child **story vBRIEFs**. Link
 Scope vBRIEFs are durable scope records (the *what*); `plan.vbrief.json` remains the ephemeral session-level tactical plan (the *how right now*); `continue.vbrief.json` remains the interruption checkpoint. Both gain a parent reference to scope vBRIEFs via `planRef`.
 
 - **Scope vBRIEF** — acceptance criteria, scope definition, origin provenance. Durable across sessions. Shared between agents.
-- **plan.vbrief.json** — granular implementation steps for this session. Ephemeral. Agent-private.
+- **plan.vbrief.json** — granular implementation steps for this session. Session-durable. Agent-private.
 - **continue.vbrief.json** — interruption checkpoint. References scope vBRIEF(s) being worked on.
 
-- ! plan.vbrief.json and continue.vbrief.json MUST carry a `planRef` to the scope vBRIEF(s) they relate to
+- ! When scope vBRIEFs exist, plan.vbrief.json and continue.vbrief.json MUST carry a `planRef` to the scope vBRIEF(s) they relate to
 - ⊗ Use scope vBRIEFs as session scratchpads — that is what plan.vbrief.json is for
 
 ### Scope Splitting

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -57,6 +57,7 @@ Individual units of work (features, bugs, initiatives) live as scope vBRIEFs in 
 - ! `plan.status` inside each scope vBRIEF is the **source of truth** — not the folder location
 - ! Folder location is a convenience view for humans; metadata is authoritative
 - ! Agents MUST move files to the matching lifecycle folder when status changes
+- ! When moving a file, agents MUST update all `planRef` and `references[].url` values in other scope vBRIEFs that point to the moved file
 - ~ When folder/status drift is detected, trust the status field and correct the folder
 - ⊗ Move files between folders without updating `plan.status`
 
@@ -133,8 +134,9 @@ When a scope grows too large, the parent vBRIEF becomes an epic and children are
 2. Parent vBRIEF promoted to epic
 3. Child story vBRIEFs created with `planRef` back to parent
 4. Parent epic's `references` updated to list all child paths
-5. Acceptance criteria redistributed by agent with user approval
-6. Origin provenance stays on the parent epic; children inherit via epic relationship
+5. Update `plan.vbrief.json` (and `continue.vbrief.json` if present) `planRef` to reference child scope vBRIEFs
+6. Acceptance criteria redistributed by agent with user approval
+7. Origin provenance stays on the parent epic; children inherit via epic relationship
 
 - ! Scope splitting is agent-driven using existing tools — no dedicated split command
 - ~ Uses existing `scope:*` commands for lifecycle transitions after splitting
@@ -310,8 +312,31 @@ The source-of-truth for project intent. Created via the interview process in
 The synthesized project identity — what this project IS right now. Uses the existing vBRIEF v0.5 schema:
 
 - `narratives` holds project identity: overview, tech stack, architecture, risks/unknowns, configuration
-- `items` acts as a registry of active scopes, each referencing its individual scope vBRIEF file
+- `items` acts as a registry of active scopes, each referencing its individual scope vBRIEF file via `references`
 - `plan.status` represents overall project state (e.g. `running`, `draft`)
+
+```json
+{
+  "plan": {
+    "title": "My Project",
+    "status": "running",
+    "narratives": {
+      "Overview": "A CLI tool for ...",
+      "TechStack": "Go 1.22, Python 3.11",
+      "Risks": "No known blockers"
+    },
+    "items": [
+      {
+        "title": "Add OAuth flow",
+        "status": "running",
+        "references": [
+          { "type": "x-vbrief/plan", "url": "./active/2026-04-12-add-oauth-flow.vbrief.json" }
+        ]
+      }
+    ]
+  }
+}
+```
 
 **Regeneration**: Deterministic tooling updates the items registry from folder contents; agent-assisted layer reviews and proposes narrative updates with user approval.
 

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -93,6 +93,7 @@ Larger initiatives use **epic vBRIEFs** linking to child **story vBRIEFs**. Link
 **Epic → Stories** (via `references`):
 ```json
 {
+  "vBRIEFInfo": { "version": "0.5" },
   "plan": {
     "title": "Auth system overhaul",
     "status": "running",
@@ -107,6 +108,7 @@ Larger initiatives use **epic vBRIEFs** linking to child **story vBRIEFs**. Link
 **Story → Epic** (via `planRef`):
 ```json
 {
+  "vBRIEFInfo": { "version": "0.5" },
   "plan": {
     "title": "Implement OAuth flow",
     "status": "running",
@@ -312,11 +314,12 @@ The source-of-truth for project intent. Created via the interview process in
 The synthesized project identity — what this project IS right now. Uses the existing vBRIEF v0.5 schema:
 
 - `narratives` holds project identity: overview, tech stack, architecture, risks/unknowns, configuration
-- `items` acts as a registry of active scopes, each referencing its individual scope vBRIEF file via `references`
+- `items` acts as a registry of project scopes across all lifecycle folders, each referencing its individual scope vBRIEF file via `references`
 - `plan.status` represents overall project state (e.g. `running`, `draft`)
 
 ```json
 {
+  "vBRIEFInfo": { "version": "0.5" },
   "plan": {
     "title": "My Project",
     "status": "running",

--- a/vbrief/vbrief.md
+++ b/vbrief/vbrief.md
@@ -57,7 +57,7 @@ Individual units of work (features, bugs, initiatives) live as scope vBRIEFs in 
 - ! `plan.status` inside each scope vBRIEF is the **source of truth** — not the folder location
 - ! Folder location is a convenience view for humans; metadata is authoritative
 - ! Agents MUST move files to the matching lifecycle folder when status changes
-- ! When moving a file, agents MUST update all `planRef` and `references[].url` values in other scope vBRIEFs that point to the moved file
+- ! When moving a file, agents MUST update all `planRef` and `references[].url` values in other scope vBRIEFs and in `PROJECT-DEFINITION.vbrief.json` that point to the moved file
 - ~ When folder/status drift is detected, trust the status field and correct the folder
 - ⊗ Move files between folders without updating `plan.status`
 


### PR DESCRIPTION
## Summary

Updates vbrief/vbrief.md with the new vBRIEF-centric document model defined in RFC #309.

Part of #309. Closes #310. Tracking: #338.

## Changes

- **File Taxonomy rewrite**: Replaced 5-type flat table with comprehensive document model
- **Lifecycle folders**: proposed/, pending/, active/, completed/, cancelled/ with status mapping
- **PROJECT-DEFINITION.vbrief.json**: New document type using existing v0.5 schema
- **Filename convention**: YYYY-MM-DD-descriptive-slug.vbrief.json
- **Status-driven moves**: plan.status is source of truth
- **Origin provenance**: Every scope vBRIEF MUST carry references to origin
- **Epic-story linking**: Bidirectional with examples
- **Coexistence**: Scope vBRIEFs + plan.vbrief.json + continue.vbrief.json via planRef
- **Scope splitting**: Agent-driven lifecycle convention
- **Anti-patterns**: 4 new entries

## Checklist

- [x] task check passes
- [x] CHANGELOG.md updated
- [x] Conventional commit
- [x] Feature branch
- [x] Documentation-only (no tests needed)
