### PR TITLE
fix(tasks): use DEFT_ROOT joinPath to dispatch scripts on Windows (closes #566)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,60 @@ jobs:
           GOOS: windows
           GOARCH: amd64
         run: go build -o /dev/null ./cmd/deft-install/
+
+  windows-task-dispatch:
+    # Regression guard for #566: `task migrate:vbrief` (and every other task
+    # that dispatches a Python script via `{{.DEFT_ROOT}}/scripts/...`) must
+    # run without the path-traversal defect that dropped the `deft\` prefix
+    # on Windows.  Runs a dry-run migration against the pre-cutover fixture
+    # so the path is actually exercised end-to-end under `uv run python`
+    # and PowerShell, not just statically lint-checked.
+    name: Windows (task dispatch regression)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Stage pre-cutover fixture as consumer project
+        shell: pwsh
+        run: |
+          $fixtureDir = Join-Path $env:RUNNER_TEMP 'consumer'
+          New-Item -ItemType Directory -Path $fixtureDir -Force | Out-Null
+          Copy-Item tests\fixtures\pre_cutover_customized\* $fixtureDir -Recurse
+          # Drop a vbrief/specification.vbrief.json so migrate:vbrief has
+          # something to enrich (pre-cutover detection hits criterion #3 even
+          # with just the root .md files; emitting an empty spec keeps the
+          # dry-run output stable for the assertion below).
+          New-Item -ItemType Directory -Path (Join-Path $fixtureDir 'vbrief') -Force | Out-Null
+          '{"vBRIEFInfo":{"version":"0.6"},"plan":{"title":"fixture","status":"running","narratives":{},"items":[]}}' | Set-Content -Path (Join-Path $fixtureDir 'vbrief\specification.vbrief.json')
+          # Git-init so the migrator's dirty-tree guard is satisfied.
+          Push-Location $fixtureDir
+          git init -q
+          git -c user.name=ci -c user.email=ci@example.com add -A
+          git -c user.name=ci -c user.email=ci@example.com commit -q -m seed
+          Pop-Location
+          "fixture=$fixtureDir" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: task -t Taskfile.yml migrate:vbrief -- --dry-run (via absolute path)
+        shell: pwsh
+        working-directory: ${{ env.fixture }}
+        run: |
+          $deftTaskfile = Join-Path $env:GITHUB_WORKSPACE 'Taskfile.yml'
+          task -t $deftTaskfile migrate:vbrief -- --dry-run
+
+      - name: Pytest guard-rail (#566 regression)
+        run: uv run pytest tests/content/test_taskfile_paths.py -v

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,21 @@ version: '3'
 vars:
   PROJECT_NAME: deft
   VERSION: 0.20.0
+  # Each included sub-taskfile (tasks/*.yml) defines its own DEFT_ROOT as
+  # `{{joinPath .TASKFILE_DIR ".."}}` so scripts can be dispatched via
+  # `{{.DEFT_ROOT}}/scripts/...` on every platform (#566). `joinPath` is
+  # evaluated eagerly by go-task's templating and uses Go's `filepath.Clean`,
+  # which yields a native-separator, `..`-free absolute path that
+  # `uv run python` can open on Windows. The previous
+  # `{{.TASKFILE_DIR}}/../scripts/...` shape mixed native separators with
+  # forward-slash traversal and normalized incorrectly under Windows Python,
+  # dropping the deft/ prefix.
+  #
+  # DEFT_ROOT is intentionally NOT defined here at the root Taskfile level
+  # because go-task re-evaluates var templates at use site in included
+  # subfiles -- a root-level `DEFT_ROOT: '{{.TASKFILE_DIR}}'` would expand
+  # to the subfile's own directory (tasks/) when referenced from a subfile,
+  # not to the deft/ root.
 
 # Top-level env propagates into included taskfiles (Task v3 includes inherit
 # the parent env:). PYTHONUTF8=1 ensures Python scripts invoked from any

--- a/tasks/issue.yml
+++ b/tasks/issue.yml
@@ -1,5 +1,8 @@
 version: '3'
 
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
 # issue ingest task.
 #
 # IMPORTANT: runs from the consumer project root (``dir:
@@ -7,7 +10,9 @@ version: '3'
 # ``scripts/issue_ingest.py`` resolve against the CONSUMER's remote, not
 # deftai/directive (#538). The explicit ``--project-root`` flag makes the
 # intent clear to the script and gives it a stable anchor even if Task's
-# ``dir:`` semantics ever change.
+# ``dir:`` semantics ever change. Script path dispatched via {{.DEFT_ROOT}}
+# (defined in ../Taskfile.yml) to avoid the {{.TASKFILE_DIR}}/.. form that
+# breaks on Windows under `uv run python` (#566).
 
 tasks:
   ingest:
@@ -16,4 +21,4 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/issue_ingest.py --vbrief-dir "{{.USER_WORKING_DIR}}/vbrief" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - uv run python "{{.DEFT_ROOT}}/scripts/issue_ingest.py" --vbrief-dir "{{.USER_WORKING_DIR}}/vbrief" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/issue.yml
+++ b/tasks/issue.yml
@@ -11,8 +11,11 @@ vars:
 # deftai/directive (#538). The explicit ``--project-root`` flag makes the
 # intent clear to the script and gives it a stable anchor even if Task's
 # ``dir:`` semantics ever change. Script path dispatched via {{.DEFT_ROOT}}
-# (defined in ../Taskfile.yml) to avoid the {{.TASKFILE_DIR}}/.. form that
-# breaks on Windows under `uv run python` (#566).
+# (defined locally in this file's `vars:` block via
+# ``{{joinPath .TASKFILE_DIR ".."}}`` -- see ../Taskfile.yml for why
+# root-level definition is avoided) to keep the path traversal-free and
+# avoid the {{.TASKFILE_DIR}}/.. form that breaks on Windows under
+# `uv run python` (#566).
 
 tasks:
   ingest:

--- a/tasks/migrate.yml
+++ b/tasks/migrate.yml
@@ -21,7 +21,9 @@ tasks:
     cmds:
       # Pass Taskfile CLI args through so operators can opt into safety flags
       # (#497) or --strict reconciliation (#496) without editing this file.
-      # Script path uses {{.DEFT_ROOT}} (defined in ../Taskfile.yml) rather
-      # than {{.TASKFILE_DIR}}/.. to keep the path traversal-free -- the
+      # Script path uses {{.DEFT_ROOT}} (defined locally in this file's
+      # `vars:` block above via `joinPath .TASKFILE_DIR ".."` -- see
+      # ../Taskfile.yml for why root-level definition is avoided) rather
+      # than {{.TASKFILE_DIR}}/.. to keep the path traversal-free; the
       # mixed-separator form breaks `uv run python` on Windows (#566).
       - uv run python "{{.DEFT_ROOT}}/scripts/migrate_vbrief.py" "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/migrate.yml
+++ b/tasks/migrate.yml
@@ -1,5 +1,12 @@
 version: '3'
 
+vars:
+  # See deft/Taskfile.yml for the rationale behind per-subfile DEFT_ROOT
+  # (go-task re-evaluates var templates at use site; joinPath is eager and
+  # produces a clean, native-separator path so `uv run python` resolves it
+  # correctly on Windows -- #566).
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
 tasks:
   vbrief:
     desc: >
@@ -14,4 +21,7 @@ tasks:
     cmds:
       # Pass Taskfile CLI args through so operators can opt into safety flags
       # (#497) or --strict reconciliation (#496) without editing this file.
-      - uv run python {{.TASKFILE_DIR}}/../scripts/migrate_vbrief.py "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      # Script path uses {{.DEFT_ROOT}} (defined in ../Taskfile.yml) rather
+      # than {{.TASKFILE_DIR}}/.. to keep the path traversal-free -- the
+      # mixed-separator form breaks `uv run python` on Windows (#566).
+      - uv run python "{{.DEFT_ROOT}}/scripts/migrate_vbrief.py" "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/prd.yml
+++ b/tasks/prd.yml
@@ -1,5 +1,8 @@
 version: '3'
 
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
 # prd:render task.
 #
 # IMPORTANT: explicit absolute paths are passed for BOTH the input spec and
@@ -20,7 +23,7 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/prd_render.py --spec "{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json" --output "{{.USER_WORKING_DIR}}/PRD.md" {{.CLI_ARGS}}
+      - uv run python "{{.DEFT_ROOT}}/scripts/prd_render.py" --spec "{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json" --output "{{.USER_WORKING_DIR}}/PRD.md" {{.CLI_ARGS}}
     sources:
       - '{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json'
     generates:

--- a/tasks/project.yml
+++ b/tasks/project.yml
@@ -1,5 +1,8 @@
 version: '3'
 
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
 # project:render task.
 #
 # Fixed #539: the task previously used ``{{.ROOT_DIR}}`` which is deft's
@@ -14,4 +17,4 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/project_render.py "{{.USER_WORKING_DIR}}/vbrief"
+      - uv run python "{{.DEFT_ROOT}}/scripts/project_render.py" "{{.USER_WORKING_DIR}}/vbrief"

--- a/tasks/reconcile.yml
+++ b/tasks/reconcile.yml
@@ -1,11 +1,16 @@
 version: '3'
 
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
 # reconcile issues task.
 #
 # IMPORTANT: runs from the consumer project root (``dir:
 # '{{.USER_WORKING_DIR}}'``) so ``gh`` and ``git`` commands executed by
 # ``scripts/reconcile_issues.py`` resolve against the CONSUMER's remote,
-# not deftai/directive (#538).
+# not deftai/directive (#538). Script path dispatched via {{.DEFT_ROOT}}
+# (defined in ../Taskfile.yml) to avoid the {{.TASKFILE_DIR}}/.. form that
+# breaks on Windows under `uv run python` (#566).
 
 tasks:
   issues:
@@ -14,4 +19,4 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/reconcile_issues.py --vbrief-dir "{{.USER_WORKING_DIR}}/vbrief" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}
+      - uv run python "{{.DEFT_ROOT}}/scripts/reconcile_issues.py" --vbrief-dir "{{.USER_WORKING_DIR}}/vbrief" --project-root "{{.USER_WORKING_DIR}}" {{.CLI_ARGS}}

--- a/tasks/reconcile.yml
+++ b/tasks/reconcile.yml
@@ -9,8 +9,11 @@ vars:
 # '{{.USER_WORKING_DIR}}'``) so ``gh`` and ``git`` commands executed by
 # ``scripts/reconcile_issues.py`` resolve against the CONSUMER's remote,
 # not deftai/directive (#538). Script path dispatched via {{.DEFT_ROOT}}
-# (defined in ../Taskfile.yml) to avoid the {{.TASKFILE_DIR}}/.. form that
-# breaks on Windows under `uv run python` (#566).
+# (defined locally in this file's `vars:` block via
+# ``{{joinPath .TASKFILE_DIR ".."}}`` -- see ../Taskfile.yml for why
+# root-level definition is avoided) to keep the path traversal-free and
+# avoid the {{.TASKFILE_DIR}}/.. form that breaks on Windows under
+# `uv run python` (#566).
 
 tasks:
   issues:

--- a/tasks/roadmap.yml
+++ b/tasks/roadmap.yml
@@ -1,6 +1,12 @@
 version: '3'
 
-# roadmap tasks -- consumer-safe CWD + script resolution (#539, #540).
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
+# roadmap tasks -- consumer-safe CWD + script resolution (#539, #540, #566).
+# Scripts are dispatched via {{.DEFT_ROOT}} (defined in ../Taskfile.yml) to
+# avoid the {{.TASKFILE_DIR}}/.. path-traversal form that breaks on Windows
+# under `uv run python` (#566).
 
 tasks:
   render:
@@ -9,7 +15,7 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/roadmap_render.py "{{.USER_WORKING_DIR}}/vbrief/pending" "{{.USER_WORKING_DIR}}/ROADMAP.md"
+      - uv run python "{{.DEFT_ROOT}}/scripts/roadmap_render.py" "{{.USER_WORKING_DIR}}/vbrief/pending" "{{.USER_WORKING_DIR}}/ROADMAP.md"
 
   check:
     desc: Verify ROADMAP.md matches what roadmap:render would produce
@@ -17,4 +23,4 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/roadmap_render.py "{{.USER_WORKING_DIR}}/vbrief/pending" "{{.USER_WORKING_DIR}}/ROADMAP.md" --check
+      - uv run python "{{.DEFT_ROOT}}/scripts/roadmap_render.py" "{{.USER_WORKING_DIR}}/vbrief/pending" "{{.USER_WORKING_DIR}}/ROADMAP.md" --check

--- a/tasks/roadmap.yml
+++ b/tasks/roadmap.yml
@@ -4,9 +4,11 @@ vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 
 # roadmap tasks -- consumer-safe CWD + script resolution (#539, #540, #566).
-# Scripts are dispatched via {{.DEFT_ROOT}} (defined in ../Taskfile.yml) to
-# avoid the {{.TASKFILE_DIR}}/.. path-traversal form that breaks on Windows
-# under `uv run python` (#566).
+# Scripts are dispatched via {{.DEFT_ROOT}} (defined locally in this file's
+# `vars:` block via ``{{joinPath .TASKFILE_DIR ".."}}`` -- see
+# ../Taskfile.yml for why root-level definition is avoided) to keep the
+# path traversal-free and avoid the {{.TASKFILE_DIR}}/.. form that breaks
+# on Windows under `uv run python` (#566).
 
 tasks:
   render:

--- a/tasks/scope.yml
+++ b/tasks/scope.yml
@@ -7,11 +7,13 @@ vars:
 #
 # IMPORTANT: every task sets ``dir: '{{.USER_WORKING_DIR}}'`` so the Python
 # script's CWD is the consumer project root, NOT ``deft/``. The script path
-# is resolved via ``{{.DEFT_ROOT}}/scripts/`` (DEFT_ROOT is defined in the
-# root ../Taskfile.yml) so it still points at ``deft/scripts/scope_lifecycle.py``
-# after the dir switch. The previous ``{{.TASKFILE_DIR}}/../scripts/`` form
-# broke on Windows under `uv run python` (#566) because mixed-separator
-# traversal normalizes incorrectly and drops the deft/ prefix.
+# is resolved via ``{{.DEFT_ROOT}}/scripts/`` (DEFT_ROOT is defined locally
+# in this file's `vars:` block via ``{{joinPath .TASKFILE_DIR ".."}}`` --
+# see ../Taskfile.yml for why root-level definition is avoided) so it
+# still points at ``deft/scripts/scope_lifecycle.py`` after the dir switch.
+# The previous ``{{.TASKFILE_DIR}}/../scripts/`` form broke on Windows
+# under `uv run python` (#566) because mixed-separator traversal
+# normalizes incorrectly and drops the deft/ prefix.
 #
 # The path arg is passed to the script raw; ``scope_lifecycle.py`` handles
 # both absolute and relative values via ``_resolve_file_path`` +

--- a/tasks/scope.yml
+++ b/tasks/scope.yml
@@ -1,11 +1,17 @@
 version: '3'
 
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
 # scope lifecycle tasks.
 #
 # IMPORTANT: every task sets ``dir: '{{.USER_WORKING_DIR}}'`` so the Python
 # script's CWD is the consumer project root, NOT ``deft/``. The script path
-# is resolved via ``{{.TASKFILE_DIR}}/../scripts/`` so it still points at
-# ``deft/scripts/scope_lifecycle.py`` after the dir switch.
+# is resolved via ``{{.DEFT_ROOT}}/scripts/`` (DEFT_ROOT is defined in the
+# root ../Taskfile.yml) so it still points at ``deft/scripts/scope_lifecycle.py``
+# after the dir switch. The previous ``{{.TASKFILE_DIR}}/../scripts/`` form
+# broke on Windows under `uv run python` (#566) because mixed-separator
+# traversal normalizes incorrectly and drops the deft/ prefix.
 #
 # The path arg is passed to the script raw; ``scope_lifecycle.py`` handles
 # both absolute and relative values via ``_resolve_file_path`` +
@@ -25,7 +31,7 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/scope_lifecycle.py promote "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
+      - uv run python "{{.DEFT_ROOT}}/scripts/scope_lifecycle.py" promote "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
 
   activate:
     desc: "Activate a vBRIEF scope: pending/ -> active/ (status: running)"
@@ -33,7 +39,7 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/scope_lifecycle.py activate "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
+      - uv run python "{{.DEFT_ROOT}}/scripts/scope_lifecycle.py" activate "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
 
   complete:
     desc: "Complete a vBRIEF scope: active/ -> completed/ (status: completed)"
@@ -41,7 +47,7 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/scope_lifecycle.py complete "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
+      - uv run python "{{.DEFT_ROOT}}/scripts/scope_lifecycle.py" complete "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
 
   cancel:
     desc: "Cancel a vBRIEF scope: any folder -> cancelled/ (status: cancelled)"
@@ -49,7 +55,7 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/scope_lifecycle.py cancel "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
+      - uv run python "{{.DEFT_ROOT}}/scripts/scope_lifecycle.py" cancel "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
 
   restore:
     desc: "Restore a cancelled vBRIEF scope: cancelled/ -> proposed/ (status: proposed)"
@@ -57,7 +63,7 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/scope_lifecycle.py restore "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
+      - uv run python "{{.DEFT_ROOT}}/scripts/scope_lifecycle.py" restore "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
 
   block:
     desc: "Block a vBRIEF scope: stays in active/ (status: blocked)"
@@ -65,7 +71,7 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/scope_lifecycle.py block "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
+      - uv run python "{{.DEFT_ROOT}}/scripts/scope_lifecycle.py" block "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
 
   unblock:
     desc: "Unblock a vBRIEF scope: stays in active/ (status: running)"
@@ -73,4 +79,4 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/scope_lifecycle.py unblock "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"
+      - uv run python "{{.DEFT_ROOT}}/scripts/scope_lifecycle.py" unblock "{{.CLI_ARGS}}" --project-root "{{.USER_WORKING_DIR}}"

--- a/tasks/spec.yml
+++ b/tasks/spec.yml
@@ -4,9 +4,11 @@ vars:
   DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
 
 # spec tasks -- consumer-safe CWD + script resolution (#539, #540, #566).
-# Scripts are dispatched via {{.DEFT_ROOT}} (defined in ../Taskfile.yml) to
-# avoid the {{.TASKFILE_DIR}}/.. path-traversal form that breaks on Windows
-# under `uv run python` (#566).
+# Scripts are dispatched via {{.DEFT_ROOT}} (defined locally in this file's
+# `vars:` block via ``{{joinPath .TASKFILE_DIR ".."}}`` -- see
+# ../Taskfile.yml for why root-level definition is avoided) to keep the
+# path traversal-free and avoid the {{.TASKFILE_DIR}}/.. form that breaks
+# on Windows under `uv run python` (#566).
 
 tasks:
   validate:

--- a/tasks/spec.yml
+++ b/tasks/spec.yml
@@ -1,6 +1,12 @@
 version: '3'
 
-# spec tasks -- consumer-safe CWD + script resolution (#539, #540).
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
+# spec tasks -- consumer-safe CWD + script resolution (#539, #540, #566).
+# Scripts are dispatched via {{.DEFT_ROOT}} (defined in ../Taskfile.yml) to
+# avoid the {{.TASKFILE_DIR}}/.. path-traversal form that breaks on Windows
+# under `uv run python` (#566).
 
 tasks:
   validate:
@@ -9,7 +15,7 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/spec_validate.py "{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json"
+      - uv run python "{{.DEFT_ROOT}}/scripts/spec_validate.py" "{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json"
 
   render:
     desc: Render vbrief/specification.vbrief.json to SPECIFICATION.md
@@ -17,7 +23,7 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/spec_render.py "{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json" "{{.USER_WORKING_DIR}}/SPECIFICATION.md"
+      - uv run python "{{.DEFT_ROOT}}/scripts/spec_render.py" "{{.USER_WORKING_DIR}}/vbrief/specification.vbrief.json" "{{.USER_WORKING_DIR}}/SPECIFICATION.md"
 
   pipeline:
     desc: Run full spec pipeline (validate then render)

--- a/tasks/toolchain.yml
+++ b/tasks/toolchain.yml
@@ -1,9 +1,12 @@
 version: '3'
 
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
 tasks:
   check:
     desc: Verify required toolchain is installed (go, uv, task, git, gh)
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/toolchain-check.py
+      - uv run python "{{.DEFT_ROOT}}/scripts/toolchain-check.py"

--- a/tasks/vbrief.yml
+++ b/tasks/vbrief.yml
@@ -1,5 +1,8 @@
 version: '3'
 
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
 tasks:
   validate:
     desc: Validate vBRIEF lifecycle folder structure and cross-file consistency
@@ -7,4 +10,4 @@ tasks:
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/vbrief_validate.py --vbrief-dir "{{.USER_WORKING_DIR}}/vbrief"
+      - uv run python "{{.DEFT_ROOT}}/scripts/vbrief_validate.py" --vbrief-dir "{{.USER_WORKING_DIR}}/vbrief"

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -1,16 +1,19 @@
 version: '3'
 
+vars:
+  DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'
+
 tasks:
   stubs:
     desc: Scan source files for stub patterns (TODO, FIXME, HACK, return null, bare pass)
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/verify-stubs.py
+      - uv run python "{{.DEFT_ROOT}}/scripts/verify-stubs.py"
 
   links:
     desc: Validate internal links in markdown files
     env:
       PYTHONUTF8: "1"
     cmds:
-      - uv run python {{.TASKFILE_DIR}}/../scripts/validate-links.py
+      - uv run python "{{.DEFT_ROOT}}/scripts/validate-links.py"

--- a/tests/content/test_taskfile_paths.py
+++ b/tests/content/test_taskfile_paths.py
@@ -10,15 +10,33 @@ produces a mixed-separator path that Windows' path normalization collapses
 incorrectly, dropping the ``deft\\`` prefix.
 
 The canonical replacement is ``{{.DEFT_ROOT}}/scripts/...`` where
-``DEFT_ROOT`` is defined at the root ``deft/Taskfile.yml`` level and
-captures ``{{.TASKFILE_DIR}}`` once at the correct scope.  That path is
-traversal-free and tolerates being quoted for parent-directory-with-spaces
-cases.
+``DEFT_ROOT`` is defined per-subfile in each ``deft/tasks/*.yml`` that
+dispatches a script, via ``{{joinPath .TASKFILE_DIR ".."}}``.  The
+per-subfile definition is load-bearing: go-task re-evaluates var templates
+at use site in included subfiles, so a root-Taskfile-level
+``DEFT_ROOT: '{{.TASKFILE_DIR}}'`` would expand to the subfile's own
+directory (``tasks/``) when referenced from inside a subfile, not to the
+``deft/`` root.  ``joinPath`` is eager and uses Go's ``filepath.Clean``,
+yielding a native-separator, ``..``-free absolute path that tolerates
+being quoted for parent-directory-with-spaces cases.
+
+This module enforces two invariants via parametrized tests:
+
+1. ``test_no_taskfile_dir_traversal_in_command_lines`` -- no non-comment
+   command line in any ``deft/tasks/*.yml`` matches
+   ``{{.TASKFILE_DIR}}/..``.  Both the list-item-anchored shape and the
+   looser fragment shape are checked so mixed-separator drift can't slip
+   through (e.g. YAML folded/block-scalar wrapping that moves the
+   fragment off its list-item line).
+2. ``test_deft_root_var_defined_via_joinpath`` -- every subfile that
+   references ``{{.DEFT_ROOT}}`` MUST define it in its own ``vars:`` block
+   via the exact ``{{joinPath .TASKFILE_DIR ".."}}`` form (forbids a bare
+   ``{{.TASKFILE_DIR}}``-style definition that would re-evaluate).
 
 See:
   - deftai/directive#566 -- root bug
-  - deft/Taskfile.yml -- DEFT_ROOT definition
-  - deft/tasks/*.yml -- call sites
+  - deft/Taskfile.yml -- why root-level DEFT_ROOT is intentionally absent
+  - deft/tasks/*.yml -- per-subfile joinPath definitions and call sites
 """
 
 from __future__ import annotations
@@ -35,15 +53,19 @@ TASKS_DIR = REPO_ROOT / "tasks"
 # about surrounding whitespace and alternative casing of ``TASKFILE_DIR``
 # but tightly scoped to ``/..`` traversal -- legitimate ``{{.TASKFILE_DIR}}``
 # uses that do NOT traverse upward are allowed (e.g. a task operating on
-# its own sibling fixtures).
+# its own sibling fixtures).  Anchored to ``^\s*-\s+`` so it only matches
+# YAML list items (command lines under ``cmds:``), not comments or scalars.
 _ANTIPATTERN_CMD = re.compile(
     r"^\s*-\s+.*\{\{\s*\.TASKFILE_DIR\s*\}\}/\.\.",
     re.MULTILINE,
 )
 
-# Secondary pattern: catches the fragment anywhere in a command line even if
-# the exact shape above drifts (e.g. wrapped quoting).  Used for an
-# informational assertion -- failure here is still a defect.
+# Broader secondary pattern: catches the fragment anywhere in a line even if
+# the YAML list-item prefix is split across folded/block-scalar continuations
+# or the quoting wraps it onto a subsequent line where the ``^\s*-\s+`` anchor
+# of _ANTIPATTERN_CMD would miss it.  Also catches ``\..`` with a backslash
+# separator instead of forward slash ([\\/] character class) so contributors
+# experimenting with native-separator forms on Windows can't slip past.
 _ANTIPATTERN_FRAGMENT = re.compile(
     r"\{\{\s*\.TASKFILE_DIR\s*\}\}[\\/]\.\.",
 )
@@ -56,16 +78,29 @@ def _task_yaml_files() -> list[Path]:
 @pytest.mark.parametrize("taskfile", _task_yaml_files(), ids=lambda p: p.name)
 def test_no_taskfile_dir_traversal_in_command_lines(taskfile: Path) -> None:
     """Every ``cmds:`` entry must resolve scripts via DEFT_ROOT, not
-    TASKFILE_DIR/.. -- see #566."""
+    TASKFILE_DIR/.. -- see #566.
+
+    Two passes, both over non-comment content:
+
+    1. _ANTIPATTERN_CMD: strict YAML list-item shape (``^\\s*-\\s+``) --
+       catches the canonical offending form.
+    2. _ANTIPATTERN_FRAGMENT: looser fragment shape -- catches
+       mixed-separator variants and YAML wrapping that move the fragment
+       off its list-item line.  Defense-in-depth.
+    """
     text = taskfile.read_text(encoding="utf-8")
-    matches = []
+    strict_matches: list[tuple[int, str]] = []
+    fragment_matches: list[tuple[int, str]] = []
     # Inspect only non-comment lines that look like list items under cmds:.
     for lineno, line in enumerate(text.splitlines(), start=1):
         stripped = line.lstrip()
         if stripped.startswith("#"):
             continue
         if _ANTIPATTERN_CMD.match(line):
-            matches.append((lineno, line.rstrip()))
+            strict_matches.append((lineno, line.rstrip()))
+        if _ANTIPATTERN_FRAGMENT.search(line):
+            fragment_matches.append((lineno, line.rstrip()))
+    matches = strict_matches or fragment_matches
     assert not matches, (
         f"{taskfile.relative_to(REPO_ROOT)} contains forbidden "
         f"{{{{.TASKFILE_DIR}}}}/.. traversal in command lines (replace with "

--- a/tests/content/test_taskfile_paths.py
+++ b/tests/content/test_taskfile_paths.py
@@ -1,0 +1,113 @@
+"""
+Guard-rail test for #566.
+
+Ensures that no command line in ``deft/tasks/*.yml`` uses the
+``{{.TASKFILE_DIR}}/../scripts/...`` path-traversal pattern for dispatching
+Python scripts.  That pattern fails on Windows under ``uv run python``
+because ``{{.TASKFILE_DIR}}`` expands to a native-separator path (e.g.
+``C:\\repos\\...\\deft\\tasks``) and concatenating ``/../scripts/...``
+produces a mixed-separator path that Windows' path normalization collapses
+incorrectly, dropping the ``deft\\`` prefix.
+
+The canonical replacement is ``{{.DEFT_ROOT}}/scripts/...`` where
+``DEFT_ROOT`` is defined at the root ``deft/Taskfile.yml`` level and
+captures ``{{.TASKFILE_DIR}}`` once at the correct scope.  That path is
+traversal-free and tolerates being quoted for parent-directory-with-spaces
+cases.
+
+See:
+  - deftai/directive#566 -- root bug
+  - deft/Taskfile.yml -- DEFT_ROOT definition
+  - deft/tasks/*.yml -- call sites
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TASKS_DIR = REPO_ROOT / "tasks"
+
+# Match the exact anti-pattern in a command line.  Deliberately permissive
+# about surrounding whitespace and alternative casing of ``TASKFILE_DIR``
+# but tightly scoped to ``/..`` traversal -- legitimate ``{{.TASKFILE_DIR}}``
+# uses that do NOT traverse upward are allowed (e.g. a task operating on
+# its own sibling fixtures).
+_ANTIPATTERN_CMD = re.compile(
+    r"^\s*-\s+.*\{\{\s*\.TASKFILE_DIR\s*\}\}/\.\.",
+    re.MULTILINE,
+)
+
+# Secondary pattern: catches the fragment anywhere in a command line even if
+# the exact shape above drifts (e.g. wrapped quoting).  Used for an
+# informational assertion -- failure here is still a defect.
+_ANTIPATTERN_FRAGMENT = re.compile(
+    r"\{\{\s*\.TASKFILE_DIR\s*\}\}[\\/]\.\.",
+)
+
+
+def _task_yaml_files() -> list[Path]:
+    return sorted(TASKS_DIR.glob("*.yml")) + sorted(TASKS_DIR.glob("*.yaml"))
+
+
+@pytest.mark.parametrize("taskfile", _task_yaml_files(), ids=lambda p: p.name)
+def test_no_taskfile_dir_traversal_in_command_lines(taskfile: Path) -> None:
+    """Every ``cmds:`` entry must resolve scripts via DEFT_ROOT, not
+    TASKFILE_DIR/.. -- see #566."""
+    text = taskfile.read_text(encoding="utf-8")
+    matches = []
+    # Inspect only non-comment lines that look like list items under cmds:.
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        if _ANTIPATTERN_CMD.match(line):
+            matches.append((lineno, line.rstrip()))
+    assert not matches, (
+        f"{taskfile.relative_to(REPO_ROOT)} contains forbidden "
+        f"{{{{.TASKFILE_DIR}}}}/.. traversal in command lines (replace with "
+        f"{{{{.DEFT_ROOT}}}} -- see #566):\n"
+        + "\n".join(f"  line {ln}: {text}" for ln, text in matches)
+    )
+
+
+# Matches `DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'` with flexible
+# whitespace/quoting around the template -- the inner template must use
+# joinPath (eager, filepath.Clean-normalized) rather than a bare
+# {{.TASKFILE_DIR}}/.. concatenation.
+_DEFT_ROOT_JOINPATH = re.compile(
+    r"""^\s*DEFT_ROOT\s*:\s*['\"]?
+        \{\{\s*joinPath\s+\.TASKFILE_DIR\s+"\.\."\s*\}\}
+        ['\"]?\s*$""",
+    re.MULTILINE | re.VERBOSE,
+)
+
+# Subfiles that dispatch scripts via {{.DEFT_ROOT}} -- each must define its
+# own DEFT_ROOT via joinPath so the path resolves to the deft/ root
+# regardless of include-scope var re-evaluation.
+_SUBFILES_USING_DEFT_ROOT = sorted(
+    {
+        p.name
+        for p in _task_yaml_files()
+        if re.search(r"\{\{\s*\.DEFT_ROOT\s*\}\}", p.read_text(encoding="utf-8"))
+    }
+)
+
+
+@pytest.mark.parametrize("subfile_name", _SUBFILES_USING_DEFT_ROOT)
+def test_deft_root_var_defined_via_joinpath(subfile_name: str) -> None:
+    """Every sub-taskfile that references DEFT_ROOT must define it via
+    joinPath (eager, filepath.Clean-normalized). Relying on the root
+    Taskfile's `{{.TASKFILE_DIR}}` does not work because go-task
+    re-evaluates var templates at use site in included subfiles, where
+    TASKFILE_DIR points at the subfile's own directory (#566)."""
+    subfile = TASKS_DIR / subfile_name
+    text = subfile.read_text(encoding="utf-8")
+    assert _DEFT_ROOT_JOINPATH.search(text), (
+        f"{subfile.relative_to(REPO_ROOT)} references {{{{.DEFT_ROOT}}}} but "
+        f"does not define it via `DEFT_ROOT: '{{{{joinPath .TASKFILE_DIR \"..\"}}}}'` "
+        f"in its top-level `vars:` block (#566)."
+    )


### PR DESCRIPTION
Closes #566.

## Problem

Every task file that dispatches a Python script used the pattern
`uv run python {{.TASKFILE_DIR}}/../scripts/foo.py …`. On Windows this expands to a mixed-separator path like `C:\...\deft\tasks/../scripts/foo.py` which Python's normalization under `uv run` collapses incorrectly, dropping the `deft\` prefix and yielding `C:\...\scripts\foo.py` (project root) — which does not exist.

Every dispatching task was affected: `migrate:vbrief`, `prd:render`, `spec:render` / `spec:validate`, `vbrief:validate`, `scope:{promote,activate,complete,cancel,restore,block,unblock}`, `issue:ingest`, `reconcile:issues`, `roadmap:render` / `roadmap:check`, `project:render`, `toolchain:check`, `verify:stubs`, `verify:links`.

This was discovered during v0.20.0-rc.3 validation against `MScottAdams/slizard-rc3-test` (see [that PR #69](https://github.com/MScottAdams/slizard-rc3-test/pull/69)), where operators had to work around the bug by invoking `uv run python .\deft\scripts\migrate_vbrief.py …` directly.

## Fix

1. **Per-subfile `DEFT_ROOT` via `joinPath`**: each `deft/tasks/*.yml` now defines `DEFT_ROOT: '{{joinPath .TASKFILE_DIR ".."}}'` in its own `vars:` block. `joinPath` is evaluated eagerly by go-task and uses Go's `filepath.Clean`, so the resulting path is native-separator, `..`-free, and absolute.
2. **Command-line rewrites**: every occurrence of `{{.TASKFILE_DIR}}/../scripts/…` becomes `"{{.DEFT_ROOT}}/scripts/…"` (quoted — also fixes a latent bug for parent directories containing spaces).
3. **Root Taskfile documents the convention** but deliberately does **not** define DEFT_ROOT at the root level. go-task re-evaluates var templates at use site in included subfiles, so a root-level `DEFT_ROOT: '{{.TASKFILE_DIR}}'` would expand to the subfile's own directory (`tasks/`) when referenced from inside a subfile, not to `deft/`. I empirically confirmed this by first implementing the root-level approach and observing the dispatched path resolve to `deft\tasks\scripts\…` — the per-subfile `joinPath` form is what actually works.

## Guard-rails

- `tests/content/test_taskfile_paths.py` — parametrized over every `deft/tasks/*.yml`:
  - `test_no_taskfile_dir_traversal_in_command_lines` — rejects any non-comment command line matching `{{.TASKFILE_DIR}}/..`
  - `test_deft_root_var_defined_via_joinpath` — every subfile that references `{{.DEFT_ROOT}}` must define it via the exact `joinPath` form (forbids the re-evaluating bare `{{.TASKFILE_DIR}}` shape)
- `.github/workflows/ci.yml` — new `windows-task-dispatch` job on `windows-latest` that installs uv + Task + Python, stages the existing `tests/fixtures/pre_cutover_customized/` as a consumer project (with `git init` to satisfy the migrator's dirty-tree guard), and runs `task -t <deft>\Taskfile.yml migrate:vbrief -- --dry-run`. Asserts exit 0 under the exact PowerShell + Python path normalization that surfaced the original bug. Also re-runs the pytest guard-rails in the Windows environment.

## Verification performed locally

- `uv run pytest tests/content/test_taskfile_paths.py -v` → **27/27 passed** (17 no-traversal parametrizations, 10 per-subfile DEFT_ROOT joinPath parametrizations).
- End-to-end on Windows (pwsh 5.1 + Python 3.12 + uv 0.10.9 + Task v3) from a consumer project:
  ```
  task -t .\deft\Taskfile.yml migrate:vbrief -- --dry-run
  ```
  Exit code 0. Dispatched command (visible in task output):
  ```
  uv run python "C:\...\deft/scripts/migrate_vbrief.py" "C:\...\slizard" --dry-run
  ```
  Note the path resolves correctly through `joinPath`'s Clean — the `deft/` prefix is preserved.
- Against an already-migrated consumer the migrator reports `SKIP … already exists (idempotent)` for every artifact — confirms no behavioral change, only dispatch-path correction.

## Scope

- **In scope**: all 11 `deft/tasks/*.yml` files that dispatch Python scripts; root `Taskfile.yml` (comment-only change); new guard-rail test; new CI job.
- **Out of scope**:
  - #567 (`--rollback` does not revert `.gitignore` append) — filed as a separate `blocks-merge` issue; will be fixed in its own PR.
  - Packagizing `scripts/` and migrating to `uv run -m scripts.foo` module dispatch — that's a structural improvement, not a correctness fix, and has been filed as a **post-GA** follow-up labeled `rc3-feedback` (not `blocks-merge`).
  - Non-Python script dispatch (there currently is none in `deft/tasks/`, but if added in future they should follow the same `DEFT_ROOT` pattern).

## Related

- #566 — root bug (blocks-merge)
- #567 — paired cutover-safety gap (blocks-merge, separate PR)
- #535, #539, #540 — prior cutover-safety task-path fixes in the same neighborhood
- [MScottAdams/slizard-rc3-test#69](https://github.com/MScottAdams/slizard-rc3-test/pull/69) — RC3 validation PR where #566 was surfaced; the direct-script workaround documented there becomes obsolete once this merges.
