### PR TITLE
refinement: ingest and triage issues #622-#642 into Phase 1/2 backlog

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,6 +76,7 @@ Urgent fixes to land ahead of broader roadmap work.
 - **#636** -- installer: Go installer must read templates/agents-entry.md instead of hardcoded agentsMDEntry const (follow-up to #358 Option 3)
 - **#638** -- refinement: batch roadmap/project renders during multi-item triage instead of rerendering after every promotion
 - **#639** -- issue:ingest emits legacy v0.5 scope vBRIEFs and non-canonical references instead of canonical v0.6
+- **#641** -- roadmap:render should sort Phase X sections numerically instead of preserving incidental file order
 
 ## Completed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,6 +61,22 @@ Complements the Go installer (which targets novice/bare-machine users).
 - **#228** -- Bring run CLI into test coverage measurement -- refactor run/run.py to separate pure logic from terminal I/O, add unit tests, remove pyproject.toml omit entries (confirm #160 disposition before implementing)
 - **#74** -- Automate release process
 
+## Phase 2
+
+- **#624** -- feat(swarm): encode writes-single-threaded principle and named manager-child anti-patterns in deft-swarm
+- **#628** -- chore(sync): complete Phase 6c LegacyArtifacts review for v0.20.0 self-migration (120 sections deferred)
+- **#629** -- chore(conventions): document migration-artifact exclusion pattern for consumer content-linting tests
+- **#630** -- migrator: auto-invoke render tasks at end of task migrate:vbrief
+- **#642** -- tracking: framework maintainability, rule ownership, and determinism codification (PR #401)
+
+## Phase 1 -- Fix Now
+
+Urgent fixes to land ahead of broader roadmap work.
+
+- **#636** -- installer: Go installer must read templates/agents-entry.md instead of hardcoded agentsMDEntry const (follow-up to #358 Option 3)
+- **#638** -- refinement: batch roadmap/project renders during multi-item triage instead of rerendering after every promotion
+- **#639** -- issue:ingest emits legacy v0.5 scope vBRIEFs and non-canonical references instead of canonical v0.6
+
 ## Completed
 
 - **#365** -- bdd strategy: move context and scenarios to vbrief; remove specs/ folder -- `[completed]`

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -2,7 +2,7 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Project definition -- synthesized gestalt of the project.",
-    "updated": "2026-04-23T18:55:09Z"
+    "updated": "2026-04-24T01:37:10Z"
   },
   "plan": {
     "title": "PROJECT-DEFINITION",
@@ -241,6 +241,70 @@
         "metadata": {
           "source_path": "proposed/2026-04-23-roadmap-9-code-signing.vbrief.json",
           "lifecycle_folder": "proposed"
+        }
+      },
+      {
+        "id": "2026-04-24-622-featskills-clean-context-reviewer-principle-and-communicatio",
+        "title": "feat(skills): clean-context reviewer principle and communication bridge filter for deft-review-cycle",
+        "status": "proposed",
+        "metadata": {
+          "source_path": "proposed/2026-04-24-622-featskills-clean-context-reviewer-principle-and-communicatio.vbrief.json",
+          "lifecycle_folder": "proposed",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#622",
+              "url": "https://api.github.com/repos/deftai/directive/issues/622"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-24-623-featcontext-name-and-encode-context-rot-as-a-first-class-con",
+        "title": "feat(context): name and encode Context Rot as a first-class concept with mitigations",
+        "status": "proposed",
+        "metadata": {
+          "source_path": "proposed/2026-04-24-623-featcontext-name-and-encode-context-rot-as-a-first-class-con.vbrief.json",
+          "lifecycle_folder": "proposed",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#623",
+              "url": "https://api.github.com/repos/deftai/directive/issues/623"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-24-625-featpatterns-generator-verifier-loop-and-capability-routing",
+        "title": "feat(patterns): generator-verifier loop and capability routing as multi-agent architecture patterns",
+        "status": "proposed",
+        "metadata": {
+          "source_path": "proposed/2026-04-24-625-featpatterns-generator-verifier-loop-and-capability-routing.vbrief.json",
+          "lifecycle_folder": "proposed",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#625",
+              "url": "https://api.github.com/repos/deftai/directive/issues/625"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-24-627-featstrategies-add-strategiesdelegatemd-controlled-delegatio",
+        "title": "feat(strategies): add strategies/delegate.md — controlled delegation framework for agent-driven implementation",
+        "status": "proposed",
+        "metadata": {
+          "source_path": "proposed/2026-04-24-627-featstrategies-add-strategiesdelegatemd-controlled-delegatio.vbrief.json",
+          "lifecycle_folder": "proposed",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#627",
+              "url": "https://api.github.com/repos/deftai/directive/issues/627"
+            }
+          ]
         }
       },
       {
@@ -735,6 +799,134 @@
               "uri": "https://github.com/deftai/directive/issues/96",
               "type": "x-vbrief/github-issue",
               "title": "Issue #96: [Compliance] Config schema + compliance-aware constitution templates"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-24-624-featswarm-encode-writes-single-threaded-principle-and-named",
+        "title": "feat(swarm): encode writes-single-threaded principle and named manager-child anti-patterns in deft-swarm",
+        "status": "pending",
+        "metadata": {
+          "source_path": "pending/2026-04-24-624-featswarm-encode-writes-single-threaded-principle-and-named.vbrief.json",
+          "lifecycle_folder": "pending",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#624",
+              "url": "https://api.github.com/repos/deftai/directive/issues/624"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-24-628-choresync-complete-phase-6c-legacyartifacts-review-for-v0200",
+        "title": "chore(sync): complete Phase 6c LegacyArtifacts review for v0.20.0 self-migration (120 sections deferred)",
+        "status": "pending",
+        "metadata": {
+          "source_path": "pending/2026-04-24-628-choresync-complete-phase-6c-legacyartifacts-review-for-v0200.vbrief.json",
+          "lifecycle_folder": "pending",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#628",
+              "url": "https://api.github.com/repos/deftai/directive/issues/628"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-24-629-choreconventions-document-migration-artifact-exclusion-patte",
+        "title": "chore(conventions): document migration-artifact exclusion pattern for consumer content-linting tests",
+        "status": "pending",
+        "metadata": {
+          "source_path": "pending/2026-04-24-629-choreconventions-document-migration-artifact-exclusion-patte.vbrief.json",
+          "lifecycle_folder": "pending",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#629",
+              "url": "https://api.github.com/repos/deftai/directive/issues/629"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-24-630-migrator-auto-invoke-render-tasks-at-end-of-task-migratevbri",
+        "title": "migrator: auto-invoke render tasks at end of task migrate:vbrief",
+        "status": "pending",
+        "metadata": {
+          "source_path": "pending/2026-04-24-630-migrator-auto-invoke-render-tasks-at-end-of-task-migratevbri.vbrief.json",
+          "lifecycle_folder": "pending",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#630",
+              "url": "https://api.github.com/repos/deftai/directive/issues/630"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-24-636-installer-go-installer-must-read-templatesagents-entrymd-ins",
+        "title": "installer: Go installer must read templates/agents-entry.md instead of hardcoded agentsMDEntry const (follow-up to #358 Option 3)",
+        "status": "pending",
+        "metadata": {
+          "source_path": "pending/2026-04-24-636-installer-go-installer-must-read-templatesagents-entrymd-ins.vbrief.json",
+          "lifecycle_folder": "pending",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#636",
+              "url": "https://api.github.com/repos/deftai/directive/issues/636"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-24-638-refinement-batch-roadmapproject-renders-during-multi-item-tr",
+        "title": "refinement: batch roadmap/project renders during multi-item triage instead of rerendering after every promotion",
+        "status": "pending",
+        "metadata": {
+          "source_path": "pending/2026-04-24-638-refinement-batch-roadmapproject-renders-during-multi-item-tr.vbrief.json",
+          "lifecycle_folder": "pending",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#638",
+              "url": "https://api.github.com/repos/deftai/directive/issues/638"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-24-639-issueingest-emits-legacy-v05-scope-vbriefs-and-non-canonical",
+        "title": "issue:ingest emits legacy v0.5 scope vBRIEFs and non-canonical references instead of canonical v0.6",
+        "status": "pending",
+        "metadata": {
+          "source_path": "pending/2026-04-24-639-issueingest-emits-legacy-v05-scope-vbriefs-and-non-canonical.vbrief.json",
+          "lifecycle_folder": "pending",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#639",
+              "url": "https://api.github.com/repos/deftai/directive/issues/639"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-24-642-tracking-framework-maintainability-rule-ownership-and-determ",
+        "title": "tracking: framework maintainability, rule ownership, and determinism codification (PR #401)",
+        "status": "pending",
+        "metadata": {
+          "source_path": "pending/2026-04-24-642-tracking-framework-maintainability-rule-ownership-and-determ.vbrief.json",
+          "lifecycle_folder": "pending",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#642",
+              "url": "https://api.github.com/repos/deftai/directive/issues/642"
             }
           ]
         }

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -2,7 +2,7 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Project definition -- synthesized gestalt of the project.",
-    "updated": "2026-04-24T01:37:10Z"
+    "updated": "2026-04-24T01:55:32Z"
   },
   "plan": {
     "title": "PROJECT-DEFINITION",
@@ -911,6 +911,22 @@
               "type": "github-issue",
               "id": "#639",
               "url": "https://api.github.com/repos/deftai/directive/issues/639"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-24-641-roadmaprender-should-sort-phase-x-sections-numerically-inste",
+        "title": "roadmap:render should sort Phase X sections numerically instead of preserving incidental file order",
+        "status": "pending",
+        "metadata": {
+          "source_path": "pending/2026-04-24-641-roadmaprender-should-sort-phase-x-sections-numerically-inste.vbrief.json",
+          "lifecycle_folder": "pending",
+          "references": [
+            {
+              "type": "github-issue",
+              "id": "#641",
+              "url": "https://api.github.com/repos/deftai/directive/issues/641"
             }
           ]
         }

--- a/vbrief/pending/2026-04-24-624-featswarm-encode-writes-single-threaded-principle-and-named.vbrief.json
+++ b/vbrief/pending/2026-04-24-624-featswarm-encode-writes-single-threaded-principle-and-named.vbrief.json
@@ -1,0 +1,29 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #624"
+  },
+  "plan": {
+    "title": "feat(swarm): encode writes-single-threaded principle and named manager-child anti-patterns in deft-swarm",
+    "status": "pending",
+    "narratives": {
+      "Description": "feat(swarm): encode writes-single-threaded principle and named manager-child anti-patterns in deft-swarm",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/624",
+      "Labels": "enhancement, skills"
+    },
+    "items": [],
+    "metadata": {
+      "x-migrator": {
+        "Phase": "Phase 2"
+      }
+    },
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#624",
+        "url": "https://api.github.com/repos/deftai/directive/issues/624"
+      }
+    ],
+    "updated": "2026-04-24T01:23:53Z"
+  }
+}

--- a/vbrief/pending/2026-04-24-628-choresync-complete-phase-6c-legacyartifacts-review-for-v0200.vbrief.json
+++ b/vbrief/pending/2026-04-24-628-choresync-complete-phase-6c-legacyartifacts-review-for-v0200.vbrief.json
@@ -1,0 +1,29 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #628"
+  },
+  "plan": {
+    "title": "chore(sync): complete Phase 6c LegacyArtifacts review for v0.20.0 self-migration (120 sections deferred)",
+    "status": "pending",
+    "narratives": {
+      "Description": "chore(sync): complete Phase 6c LegacyArtifacts review for v0.20.0 self-migration (120 sections deferred)",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/628",
+      "Labels": "chore, skills, operational"
+    },
+    "items": [],
+    "metadata": {
+      "x-migrator": {
+        "Phase": "Phase 2"
+      }
+    },
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#628",
+        "url": "https://api.github.com/repos/deftai/directive/issues/628"
+      }
+    ],
+    "updated": "2026-04-24T01:16:04Z"
+  }
+}

--- a/vbrief/pending/2026-04-24-629-choreconventions-document-migration-artifact-exclusion-patte.vbrief.json
+++ b/vbrief/pending/2026-04-24-629-choreconventions-document-migration-artifact-exclusion-patte.vbrief.json
@@ -1,0 +1,29 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #629"
+  },
+  "plan": {
+    "title": "chore(conventions): document migration-artifact exclusion pattern for consumer content-linting tests",
+    "status": "pending",
+    "narratives": {
+      "Description": "chore(conventions): document migration-artifact exclusion pattern for consumer content-linting tests",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/629",
+      "Labels": "chore, docs, operational"
+    },
+    "items": [],
+    "metadata": {
+      "x-migrator": {
+        "Phase": "Phase 2"
+      }
+    },
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#629",
+        "url": "https://api.github.com/repos/deftai/directive/issues/629"
+      }
+    ],
+    "updated": "2026-04-24T01:13:52Z"
+  }
+}

--- a/vbrief/pending/2026-04-24-630-migrator-auto-invoke-render-tasks-at-end-of-task-migratevbri.vbrief.json
+++ b/vbrief/pending/2026-04-24-630-migrator-auto-invoke-render-tasks-at-end-of-task-migratevbri.vbrief.json
@@ -1,0 +1,29 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #630"
+  },
+  "plan": {
+    "title": "migrator: auto-invoke render tasks at end of task migrate:vbrief",
+    "status": "pending",
+    "narratives": {
+      "Description": "migrator: auto-invoke render tasks at end of task migrate:vbrief",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/630",
+      "Labels": "enhancement"
+    },
+    "items": [],
+    "metadata": {
+      "x-migrator": {
+        "Phase": "Phase 2"
+      }
+    },
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#630",
+        "url": "https://api.github.com/repos/deftai/directive/issues/630"
+      }
+    ],
+    "updated": "2026-04-24T01:11:39Z"
+  }
+}

--- a/vbrief/pending/2026-04-24-636-installer-go-installer-must-read-templatesagents-entrymd-ins.vbrief.json
+++ b/vbrief/pending/2026-04-24-636-installer-go-installer-must-read-templatesagents-entrymd-ins.vbrief.json
@@ -1,0 +1,29 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #636"
+  },
+  "plan": {
+    "title": "installer: Go installer must read templates/agents-entry.md instead of hardcoded agentsMDEntry const (follow-up to #358 Option 3)",
+    "status": "pending",
+    "narratives": {
+      "Description": "installer: Go installer must read templates/agents-entry.md instead of hardcoded agentsMDEntry const (follow-up to #358 Option 3)",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/636"
+    },
+    "items": [],
+    "metadata": {
+      "x-migrator": {
+        "Phase": "Phase 1 -- Fix Now",
+        "PhaseDescription": "Urgent fixes to land ahead of broader roadmap work."
+      }
+    },
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#636",
+        "url": "https://api.github.com/repos/deftai/directive/issues/636"
+      }
+    ],
+    "updated": "2026-04-24T00:18:09Z"
+  }
+}

--- a/vbrief/pending/2026-04-24-638-refinement-batch-roadmapproject-renders-during-multi-item-tr.vbrief.json
+++ b/vbrief/pending/2026-04-24-638-refinement-batch-roadmapproject-renders-during-multi-item-tr.vbrief.json
@@ -1,0 +1,29 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #638"
+  },
+  "plan": {
+    "title": "refinement: batch roadmap/project renders during multi-item triage instead of rerendering after every promotion",
+    "status": "pending",
+    "narratives": {
+      "Description": "refinement: batch roadmap/project renders during multi-item triage instead of rerendering after every promotion",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/638"
+    },
+    "items": [],
+    "metadata": {
+      "x-migrator": {
+        "Phase": "Phase 1 -- Fix Now",
+        "PhaseDescription": "Urgent fixes to land ahead of broader roadmap work."
+      }
+    },
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#638",
+        "url": "https://api.github.com/repos/deftai/directive/issues/638"
+      }
+    ],
+    "updated": "2026-04-24T00:35:28Z"
+  }
+}

--- a/vbrief/pending/2026-04-24-639-issueingest-emits-legacy-v05-scope-vbriefs-and-non-canonical.vbrief.json
+++ b/vbrief/pending/2026-04-24-639-issueingest-emits-legacy-v05-scope-vbriefs-and-non-canonical.vbrief.json
@@ -1,0 +1,29 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #639"
+  },
+  "plan": {
+    "title": "issue:ingest emits legacy v0.5 scope vBRIEFs and non-canonical references instead of canonical v0.6",
+    "status": "pending",
+    "narratives": {
+      "Description": "issue:ingest emits legacy v0.5 scope vBRIEFs and non-canonical references instead of canonical v0.6",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/639"
+    },
+    "items": [],
+    "metadata": {
+      "x-migrator": {
+        "Phase": "Phase 1 -- Fix Now",
+        "PhaseDescription": "Urgent fixes to land ahead of broader roadmap work."
+      }
+    },
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#639",
+        "url": "https://api.github.com/repos/deftai/directive/issues/639"
+      }
+    ],
+    "updated": "2026-04-24T00:35:32Z"
+  }
+}

--- a/vbrief/pending/2026-04-24-641-roadmaprender-should-sort-phase-x-sections-numerically-inste.vbrief.json
+++ b/vbrief/pending/2026-04-24-641-roadmaprender-should-sort-phase-x-sections-numerically-inste.vbrief.json
@@ -1,0 +1,29 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #641"
+  },
+  "plan": {
+    "title": "roadmap:render should sort Phase X sections numerically instead of preserving incidental file order",
+    "status": "pending",
+    "narratives": {
+      "Description": "roadmap:render should sort Phase X sections numerically instead of preserving incidental file order",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/641"
+    },
+    "items": [],
+    "metadata": {
+      "x-migrator": {
+        "Phase": "Phase 1 -- Fix Now",
+        "PhaseDescription": "Urgent fixes to land ahead of broader roadmap work."
+      }
+    },
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#641",
+        "url": "https://api.github.com/repos/deftai/directive/issues/641"
+      }
+    ],
+    "updated": "2026-04-24T01:54:00Z"
+  }
+}

--- a/vbrief/pending/2026-04-24-642-tracking-framework-maintainability-rule-ownership-and-determ.vbrief.json
+++ b/vbrief/pending/2026-04-24-642-tracking-framework-maintainability-rule-ownership-and-determ.vbrief.json
@@ -1,0 +1,28 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #642"
+  },
+  "plan": {
+    "title": "tracking: framework maintainability, rule ownership, and determinism codification (PR #401)",
+    "status": "pending",
+    "narratives": {
+      "Description": "tracking: framework maintainability, rule ownership, and determinism codification (PR #401)",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/642"
+    },
+    "items": [],
+    "metadata": {
+      "x-migrator": {
+        "Phase": "Phase 2"
+      }
+    },
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#642",
+        "url": "https://api.github.com/repos/deftai/directive/issues/642"
+      }
+    ],
+    "updated": "2026-04-24T01:08:34Z"
+  }
+}

--- a/vbrief/proposed/2026-04-24-622-featskills-clean-context-reviewer-principle-and-communicatio.vbrief.json
+++ b/vbrief/proposed/2026-04-24-622-featskills-clean-context-reviewer-principle-and-communicatio.vbrief.json
@@ -1,0 +1,23 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #622"
+  },
+  "plan": {
+    "title": "feat(skills): clean-context reviewer principle and communication bridge filter for deft-review-cycle",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(skills): clean-context reviewer principle and communication bridge filter for deft-review-cycle",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/622",
+      "Labels": "enhancement, skills"
+    },
+    "items": [],
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#622",
+        "url": "https://api.github.com/repos/deftai/directive/issues/622"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-04-24-623-featcontext-name-and-encode-context-rot-as-a-first-class-con.vbrief.json
+++ b/vbrief/proposed/2026-04-24-623-featcontext-name-and-encode-context-rot-as-a-first-class-con.vbrief.json
@@ -1,0 +1,23 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #623"
+  },
+  "plan": {
+    "title": "feat(context): name and encode Context Rot as a first-class concept with mitigations",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(context): name and encode Context Rot as a first-class concept with mitigations",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/623",
+      "Labels": "enhancement, context-engineering"
+    },
+    "items": [],
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#623",
+        "url": "https://api.github.com/repos/deftai/directive/issues/623"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-04-24-625-featpatterns-generator-verifier-loop-and-capability-routing.vbrief.json
+++ b/vbrief/proposed/2026-04-24-625-featpatterns-generator-verifier-loop-and-capability-routing.vbrief.json
@@ -1,0 +1,23 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #625"
+  },
+  "plan": {
+    "title": "feat(patterns): generator-verifier loop and capability routing as multi-agent architecture patterns",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(patterns): generator-verifier loop and capability routing as multi-agent architecture patterns",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/625",
+      "Labels": "enhancement, patterns"
+    },
+    "items": [],
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#625",
+        "url": "https://api.github.com/repos/deftai/directive/issues/625"
+      }
+    ]
+  }
+}

--- a/vbrief/proposed/2026-04-24-627-featstrategies-add-strategiesdelegatemd-controlled-delegatio.vbrief.json
+++ b/vbrief/proposed/2026-04-24-627-featstrategies-add-strategiesdelegatemd-controlled-delegatio.vbrief.json
@@ -1,0 +1,23 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #627"
+  },
+  "plan": {
+    "title": "feat(strategies): add strategies/delegate.md — controlled delegation framework for agent-driven implementation",
+    "status": "proposed",
+    "narratives": {
+      "Description": "feat(strategies): add strategies/delegate.md — controlled delegation framework for agent-driven implementation",
+      "Origin": "Ingested from https://api.github.com/repos/deftai/directive/issues/627",
+      "Labels": "enhancement, skills, research-strategy"
+    },
+    "items": [],
+    "references": [
+      {
+        "type": "github-issue",
+        "id": "#627",
+        "url": "https://api.github.com/repos/deftai/directive/issues/627"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Refinement: Ingest and Triage Issues #622-#642

Backlog triage session ingesting open issues into the vBRIEF lifecycle and organizing into phased roadmap.

### Phase 1 -- Fix Now
- **#636** -- Go installer must read `templates/agents-entry.md` instead of hardcoded const
- **#638** -- Batch roadmap/project renders during multi-item triage
- **#639** -- `issue:ingest` emits legacy v0.5 scope vBRIEFs instead of canonical v0.6

### Phase 2
- **#624** -- Encode writes-single-threaded principle in deft-swarm
- **#628** -- Complete Phase 6c LegacyArtifacts review for v0.20.0
- **#629** -- Document migration-artifact exclusion pattern
- **#630** -- Auto-invoke render tasks at end of `task migrate:vbrief`
- **#642** -- Framework maintainability, rule ownership, determinism codification (PR #401 tracking)

### Proposed (future consideration)
- **#622** -- Clean-context reviewer principle for deft-review-cycle
- **#623** -- Context Rot as first-class concept
- **#625** -- Generator-verifier loop and capability routing patterns
- **#627** -- `strategies/delegate.md` controlled delegation framework

### Changes
- `ROADMAP.md` -- Added Phase 1 and Phase 2 sections
- `vbrief/PROJECT-DEFINITION.vbrief.json` -- Added 12 new lifecycle items
- 8 new scope vBRIEFs in `vbrief/pending/`
- 4 new scope vBRIEFs in `vbrief/proposed/`
- All vBRIEFs at canonical v0.6 schema

---
[Warp conversation](https://app.warp.dev/conversation/5ef6a232-59de-4fd0-a882-18487911a9aa)
