### PR TITLE
chore(vbrief): move Phase 1 swarm vBRIEFs to completed/ post-v0.20.2

### DIFF
--- a/vbrief/completed/2026-04-24-636-installer-go-installer-must-read-templatesagents-entrymd-ins.vbrief.json
+++ b/vbrief/completed/2026-04-24-636-installer-go-installer-must-read-templatesagents-entrymd-ins.vbrief.json
@@ -6,7 +6,7 @@
   },
   "plan": {
     "title": "installer: Go installer must read templates/agents-entry.md instead of hardcoded agentsMDEntry const (follow-up to #358 Option 3)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Overview": "Go installer (cmd/deft-install/setup.go) still writes AGENTS.md from a hardcoded const agentsMDEntry, even though #358 introduced templates/agents-entry.md as the intended single source of truth. Four writers of the AGENTS.md body exist today and do not agree on a source: task agents:init and QUICK-START.md read the template, setup.go uses the hardcoded const, and the webinstaller probes a different path. This creates ongoing dual-maintenance tax (e.g. #428 lists both files as affected). Follow-up to #358 Option 3: installer reads template at build time.",
       "Problem": "cmd/deft-install/setup.go::WriteAgentsMD writes hardcoded const agentsMDEntry (lines 18-64) instead of reading templates/agents-entry.md, forcing manual dual-maintenance across the Go installer, task agents:init, and QUICK-START.md.",
@@ -55,6 +55,6 @@
         "title": "Issue #636: installer: Go installer must read templates/agents-entry.md instead of hardcoded agentsMDEntry const (follow-up to #358 Option 3)"
       }
     ],
-    "updated": "2026-04-24T14:33:29Z"
+    "updated": "2026-04-24T15:49:34Z"
   }
 }

--- a/vbrief/completed/2026-04-24-638-refinement-batch-roadmapproject-renders-during-multi-item-tr.vbrief.json
+++ b/vbrief/completed/2026-04-24-638-refinement-batch-roadmapproject-renders-during-multi-item-tr.vbrief.json
@@ -6,7 +6,7 @@
   },
   "plan": {
     "title": "refinement: batch roadmap/project renders during multi-item triage instead of rerendering after every promotion",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Overview": "skills/deft-directive-refinement/SKILL.md currently directs agents to call task roadmap:render after promotions/demotions and task project:render after significant lifecycle changes. The wording is semantically correct but operationally inefficient during conversational one-by-one triage -- agents interpret it as 'rerender after every accepted/rejected item'. A dry-run ingest preview surfacing 131 new issues would spend disproportionate time rebuilding derived artifacts instead of continuing triage. The roadmap and project artifacts are derived views; the source of truth is the lifecycle folders under vbrief/.",
       "Problem": "Refinement skill wording nudges agents into O(N) rerenders during high-volume triage, even though derived artifacts can be refreshed once per batch without loss of correctness.",
@@ -59,6 +59,6 @@
         "title": "Issue #638: refinement: batch roadmap/project renders during multi-item triage instead of rerendering after every promotion"
       }
     ],
-    "updated": "2026-04-24T14:33:29Z"
+    "updated": "2026-04-24T15:49:34Z"
   }
 }

--- a/vbrief/completed/2026-04-24-639-issueingest-emits-legacy-v05-scope-vbriefs-and-non-canonical.vbrief.json
+++ b/vbrief/completed/2026-04-24-639-issueingest-emits-legacy-v05-scope-vbriefs-and-non-canonical.vbrief.json
@@ -6,7 +6,7 @@
   },
   "plan": {
     "title": "issue:ingest emits legacy v0.5 scope vBRIEFs and non-canonical references instead of canonical v0.6",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Overview": "scripts/issue_ingest.py::_build_issue_vbrief() hardcodes vBRIEFInfo.version = '0.5' and emits legacy reference shape {type: 'github-issue', id: '#N', url: ...} instead of canonical v0.6 shape {uri, type: 'x-vbrief/github-issue', title}. The refinement skill, vendored schema, and conventions/references.md already describe the canonical shape (fixed in #534 for docs, #613 for migrator); issue:ingest is the last laggard. Freshly ingested vBRIEFs in this branch (including the #636 brief) carry the legacy shape.",
       "Problem": "task issue:ingest emits legacy v0.5 vBRIEFs with non-canonical reference shape, forcing downstream cleanup and drifting from the schema contract the rest of the tooling honors.",
@@ -55,6 +55,6 @@
         "title": "Issue #639: issue:ingest emits legacy v0.5 scope vBRIEFs and non-canonical references instead of canonical v0.6"
       }
     ],
-    "updated": "2026-04-24T14:33:29Z"
+    "updated": "2026-04-24T15:49:34Z"
   }
 }

--- a/vbrief/completed/2026-04-24-641-roadmaprender-should-sort-phase-x-sections-numerically-inste.vbrief.json
+++ b/vbrief/completed/2026-04-24-641-roadmaprender-should-sort-phase-x-sections-numerically-inste.vbrief.json
@@ -6,7 +6,7 @@
   },
   "plan": {
     "title": "roadmap:render should sort Phase X sections numerically instead of preserving incidental file order",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Overview": "task roadmap:render produces unstable semantic ordering for phase sections in ROADMAP.md. Current branch shows Phase 6, 3, 5, 4, 1 -- scripts/roadmap_render.py preserves insertion order from the first time each phase label is encountered while scanning pending vBRIEFs, so final section order depends on file discovery order rather than numeric phase. Phases should render in numeric order for a readable roadmap.",
       "Problem": "scripts/roadmap_render.py does not sort Phase X headings by numeric phase; output is non-deterministic relative to roadmap semantics.",
@@ -55,6 +55,6 @@
         "title": "Issue #641: roadmap:render should sort Phase X sections numerically instead of preserving incidental file order"
       }
     ],
-    "updated": "2026-04-24T14:33:29Z"
+    "updated": "2026-04-24T15:49:34Z"
   }
 }


### PR DESCRIPTION
Post-release lifecycle cleanup for #636, #638, #639, #641 (merged in #653, v0.20.2). Pure filesystem move via 	ask scope:complete; no content changes.