### PR TITLE
docs(vbrief): refinement session 2026-04-29 -- 5 active ingests, 3 closures, 3 spinouts, ADR-001 filed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **chore(vbrief): refinement session 2026-04-29** -- ran a bulk refinement pass. Ingested + activated 5 issues (#704, #733, #734, #737, #741), activated existing pending #163, closed #136 as resolved-upstream, closed #140 as superseded by #689 + `deft-directive-sync`, closed #151 via decomposition into #738/#739/#740, applied the `epic` label to #233, filed #742 as the ADR-001 tracking issue for the vBRIEF-as-master discussion (awaiting review; no follow-on issues filed), and re-rendered `ROADMAP.md` plus `vbrief/PROJECT-DEFINITION.vbrief.json`.
 
 ### Fixed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,7 +37,6 @@ Quick doc/content fixes that don't require code changes.
 ## Phase 4
 
 - **#128** -- CI vBRIEF schema sync check: fetch upstream `vbrief-core.schema.json` from `deftai/vBRIEF`, diff against vendored copy, fail on divergence (depends on #57)
-- **#163** -- Enforce USER.md gate in CLI path -- parity with agentic (skills) path
 - **#228** -- Bring run CLI into test coverage measurement -- refactor run/run.py to separate pure logic from terminal I/O, add unit tests, remove pyproject.toml omit entries (confirm #160 disposition before implementing)
 
 ## Phase 5 -- Package Distribution & Install UX

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -2,7 +2,7 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Project definition -- synthesized gestalt of the project.",
-    "updated": "2026-04-29T18:19:22Z"
+    "updated": "2026-04-29T21:05:53Z"
   },
   "plan": {
     "title": "PROJECT-DEFINITION",
@@ -528,22 +528,6 @@
         }
       },
       {
-        "id": "2026-04-23-163-enforce-user-md-gate-in-cli-path-parity-with-agentic",
-        "title": "Enforce USER.md gate in CLI path -- parity with agentic (skills) path",
-        "status": "pending",
-        "metadata": {
-          "source_path": "pending/2026-04-23-163-enforce-user-md-gate-in-cli-path-parity-with-agentic.vbrief.json",
-          "lifecycle_folder": "pending",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/163",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #163: Enforce USER.md gate in CLI path -- parity with agentic (skills) path"
-            }
-          ]
-        }
-      },
-      {
         "id": "2026-04-23-194-user-facing-best-practices-guide-docs-best-practices-md",
         "title": "User-facing best practices guide (`docs/best-practices.md`) -- Directive contract hierarchy usage, Warp swarming patterns, and user-oriented skill documentation; in-repo successor to premature PDF guide (#112); depends on #147 and #188 for stable content (xrefs #112, #84, #114)",
         "status": "pending",
@@ -927,6 +911,22 @@
         }
       },
       {
+        "id": "2026-04-23-163-enforce-user-md-gate-in-cli-path-parity-with-agentic",
+        "title": "Enforce USER.md gate in CLI path -- parity with agentic (skills) path",
+        "status": "running",
+        "metadata": {
+          "source_path": "active/2026-04-23-163-enforce-user-md-gate-in-cli-path-parity-with-agentic.vbrief.json",
+          "lifecycle_folder": "active",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/163",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #163: Enforce USER.md gate in CLI path -- parity with agentic (skills) path"
+            }
+          ]
+        }
+      },
+      {
         "id": "2026-04-24-642-tracking-framework-maintainability-rule-ownership-and-determ",
         "title": "PR #401 trim tracker (hygiene merge anchor)",
         "status": "running",
@@ -963,6 +963,86 @@
               "uri": "https://github.com/deftai/directive/issues/642#issuecomment-4330742436",
               "type": "x-vbrief/github-issue",
               "title": "Canonical workflow comment for PR #401 trim + framework maintainability arc (locked decisions, DP5 V4 block, halt-to-user templates, substantive-vs-mechanical bright line)"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-29-704-readme-cleanup-pass-factual-errors-contradictions-and-post-v",
+        "title": "README cleanup pass: factual errors, contradictions, and post-v0.20 staleness",
+        "status": "running",
+        "metadata": {
+          "source_path": "active/2026-04-29-704-readme-cleanup-pass-factual-errors-contradictions-and-post-v.vbrief.json",
+          "lifecycle_folder": "active",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/704",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #704: README cleanup pass: factual errors, contradictions, and post-v0.20 staleness"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-29-733-fixgithubworkflowsreleaseyml-release-job-auto-flips-draft-to",
+        "title": "fix(.github/workflows/release.yml): release job auto-flips draft to public, bypassing #716 / Phase 5 user-only authority gate",
+        "status": "running",
+        "metadata": {
+          "source_path": "active/2026-04-29-733-fixgithubworkflowsreleaseyml-release-job-auto-flips-draft-to.vbrief.json",
+          "lifecycle_folder": "active",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/733",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #733: fix(.github/workflows/release.yml): release job auto-flips draft to public, bypassing #716 / Phase 5 user-only authority gate"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-29-734-featscriptsskills-vbrief-lifecycle-reconciliation-gate-at-ta",
+        "title": "feat(scripts,skills): vBRIEF-lifecycle reconciliation -- gate at task release Phase 1 + --apply-lifecycle-fixes on reconcile_issues.py",
+        "status": "running",
+        "metadata": {
+          "source_path": "active/2026-04-29-734-featscriptsskills-vbrief-lifecycle-reconciliation-gate-at-ta.vbrief.json",
+          "lifecycle_folder": "active",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/734",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #734: feat(scripts,skills): vBRIEF-lifecycle reconciliation -- gate at task release Phase 1 + --apply-lifecycle-fixes on reconcile_issues.py"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-29-737-featscriptstasksskills-pre-pr-closing-keyword-negation-conte",
+        "title": "feat(scripts,tasks,skills): pre-PR closing-keyword negation-context lint to prevent Layer 0 false-positive auto-closes",
+        "status": "running",
+        "metadata": {
+          "source_path": "active/2026-04-29-737-featscriptstasksskills-pre-pr-closing-keyword-negation-conte.vbrief.json",
+          "lifecycle_folder": "active",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/737",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #737: feat(scripts,tasks,skills): pre-PR closing-keyword negation-context lint to prevent Layer 0 false-positive auto-closes"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-04-29-741-fixscriptsreleasepy-bump-version-literal-in-run-during-relea",
+        "title": "fix(scripts/release.py): bump VERSION literal in run during release flow",
+        "status": "running",
+        "metadata": {
+          "source_path": "active/2026-04-29-741-fixscriptsreleasepy-bump-version-literal-in-run-during-relea.vbrief.json",
+          "lifecycle_folder": "active",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/741",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #741: fix(scripts/release.py): bump VERSION literal in run during release flow"
             }
           ]
         }

--- a/vbrief/active/2026-04-23-163-enforce-user-md-gate-in-cli-path-parity-with-agentic.vbrief.json
+++ b/vbrief/active/2026-04-23-163-enforce-user-md-gate-in-cli-path-parity-with-agentic.vbrief.json
@@ -5,7 +5,7 @@
   },
   "plan": {
     "title": "Enforce USER.md gate in CLI path -- parity with agentic (skills) path",
-    "status": "pending",
+    "status": "running",
     "narratives": {
       "SourceSection": "ROADMAP active phase"
     },
@@ -27,6 +27,6 @@
         "title": "Issue #163: Enforce USER.md gate in CLI path -- parity with agentic (skills) path"
       }
     ],
-    "updated": "2026-04-23T18:53:14Z"
+    "updated": "2026-04-29T20:04:02Z"
   }
 }

--- a/vbrief/active/2026-04-29-704-readme-cleanup-pass-factual-errors-contradictions-and-post-v.vbrief.json
+++ b/vbrief/active/2026-04-29-704-readme-cleanup-pass-factual-errors-contradictions-and-post-v.vbrief.json
@@ -1,0 +1,24 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #704"
+  },
+  "plan": {
+    "title": "README cleanup pass: factual errors, contradictions, and post-v0.20 staleness",
+    "status": "running",
+    "narratives": {
+      "Description": "README cleanup pass: factual errors, contradictions, and post-v0.20 staleness",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/704",
+      "Labels": "documentation, adoption-blocker"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/704",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #704: README cleanup pass: factual errors, contradictions, and post-v0.20 staleness"
+      }
+    ],
+    "updated": "2026-04-29T19:31:20Z"
+  }
+}

--- a/vbrief/active/2026-04-29-733-fixgithubworkflowsreleaseyml-release-job-auto-flips-draft-to.vbrief.json
+++ b/vbrief/active/2026-04-29-733-fixgithubworkflowsreleaseyml-release-job-auto-flips-draft-to.vbrief.json
@@ -1,0 +1,24 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #733"
+  },
+  "plan": {
+    "title": "fix(.github/workflows/release.yml): release job auto-flips draft to public, bypassing #716 / Phase 5 user-only authority gate",
+    "status": "running",
+    "narratives": {
+      "Description": "fix(.github/workflows/release.yml): release job auto-flips draft to public, bypassing #716 / Phase 5 user-only authority gate",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/733",
+      "Labels": "bug, determinism, adoption-blocker, test-debt"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/733",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #733: fix(.github/workflows/release.yml): release job auto-flips draft to public, bypassing #716 / Phase 5 user-only authority gate"
+      }
+    ],
+    "updated": "2026-04-29T19:31:20Z"
+  }
+}

--- a/vbrief/active/2026-04-29-734-featscriptsskills-vbrief-lifecycle-reconciliation-gate-at-ta.vbrief.json
+++ b/vbrief/active/2026-04-29-734-featscriptsskills-vbrief-lifecycle-reconciliation-gate-at-ta.vbrief.json
@@ -1,0 +1,24 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #734"
+  },
+  "plan": {
+    "title": "feat(scripts,skills): vBRIEF-lifecycle reconciliation -- gate at task release Phase 1 + --apply-lifecycle-fixes on reconcile_issues.py",
+    "status": "running",
+    "narratives": {
+      "Description": "feat(scripts,skills): vBRIEF-lifecycle reconciliation -- gate at task release Phase 1 + --apply-lifecycle-fixes on reconcile_issues.py",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/734",
+      "Labels": "enhancement, skills, determinism, adoption-blocker, test-debt"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/734",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #734: feat(scripts,skills): vBRIEF-lifecycle reconciliation -- gate at task release Phase 1 + --apply-lifecycle-fixes on reconcile_issues.py"
+      }
+    ],
+    "updated": "2026-04-29T19:31:20Z"
+  }
+}

--- a/vbrief/active/2026-04-29-737-featscriptstasksskills-pre-pr-closing-keyword-negation-conte.vbrief.json
+++ b/vbrief/active/2026-04-29-737-featscriptstasksskills-pre-pr-closing-keyword-negation-conte.vbrief.json
@@ -1,0 +1,24 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #737"
+  },
+  "plan": {
+    "title": "feat(scripts,tasks,skills): pre-PR closing-keyword negation-context lint to prevent Layer 0 false-positive auto-closes",
+    "status": "running",
+    "narratives": {
+      "Description": "feat(scripts,tasks,skills): pre-PR closing-keyword negation-context lint to prevent Layer 0 false-positive auto-closes",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/737",
+      "Labels": "bug, determinism, adoption-blocker, test-debt"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/737",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #737: feat(scripts,tasks,skills): pre-PR closing-keyword negation-context lint to prevent Layer 0 false-positive auto-closes"
+      }
+    ],
+    "updated": "2026-04-29T19:31:20Z"
+  }
+}

--- a/vbrief/active/2026-04-29-741-fixscriptsreleasepy-bump-version-literal-in-run-during-relea.vbrief.json
+++ b/vbrief/active/2026-04-29-741-fixscriptsreleasepy-bump-version-literal-in-run-during-relea.vbrief.json
@@ -1,0 +1,24 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "description": "Scope vBRIEF ingested from GitHub issue #741"
+  },
+  "plan": {
+    "title": "fix(scripts/release.py): bump VERSION literal in run during release flow",
+    "status": "running",
+    "narratives": {
+      "Description": "fix(scripts/release.py): bump VERSION literal in run during release flow",
+      "Origin": "Ingested from https://github.com/deftai/directive/issues/741",
+      "Labels": "bug, blocks-release-tag, ci-cd, operational, determinism, test-debt"
+    },
+    "items": [],
+    "references": [
+      {
+        "uri": "https://github.com/deftai/directive/issues/741",
+        "type": "x-vbrief/github-issue",
+        "title": "Issue #741: fix(scripts/release.py): bump VERSION literal in run during release flow"
+      }
+    ],
+    "updated": "2026-04-29T19:59:57Z"
+  }
+}


### PR DESCRIPTION
## Summary

Bulk refinement pass executed via `deft-directive-refinement` skill. Touches `vbrief/` lifecycle folders, ROADMAP.md, PROJECT-DEFINITION.vbrief.json, and CHANGELOG.md only — no source code, skill, or rule changes.

This was a long brainstorming session with extensive analysis of the determinism architecture and the vBRIEF-as-master question (see #742). Most of the GitHub-side work happened during the session; this PR captures only the lifecycle-folder + render artifacts that resulted.

## vBRIEF lifecycle changes

Activated 6 vBRIEFs (5 ingested + 1 promoted from existing pending):

- `vbrief/active/2026-04-29-704-...vbrief.json` -- README cleanup pass (#704)
- `vbrief/active/2026-04-29-733-...vbrief.json` -- release.yml draft-to-public auto-flip (#733)
- `vbrief/active/2026-04-29-734-...vbrief.json` -- vBRIEF-lifecycle reconciliation gate (#734)
- `vbrief/active/2026-04-29-737-...vbrief.json` -- closing-keyword negation lint (#737)
- `vbrief/active/2026-04-29-741-...vbrief.json` -- bump VERSION literal in run during release flow (#741)
- `vbrief/active/2026-04-23-163-...vbrief.json` -- USER.md gate CLI parity (#163, moved from `pending/`)

Re-rendered:
- `ROADMAP.md`
- `vbrief/PROJECT-DEFINITION.vbrief.json` (320 scope items)

## GitHub issue changes (out-of-band)

These happened during the session but are not part of this PR's diff -- recording for traceability:

- Closed #136 as resolved-upstream (Warp now natively supports AGENTS.md auto-load per docs)
- Closed #140 as superseded by #689 + `deft-directive-sync` skill
- Closed #151 (playtest umbrella) via decomposition into 3 children:
  - **#738** -- IP/legal risk flagging during research/interview phase
  - **#739** -- pre-build cost & budget transparency phase
  - **#740** -- plain-English UX pass
- Applied `epic` label to #233 (More Determinism umbrella, intentional umbrella per its 2026-04-28 reopen)
- Filed **#742** -- ADR-001 tracking issue for the vBRIEF-as-master architectural decision (awaiting visionik review; no follow-on issues filed pending buy-in)

## Scope

This PR is **lifecycle bookkeeping only**. The architectural conversation in #742 is separate, awaiting review, and will produce its own follow-on PRs once approved.

## Checklist

- [x] CHANGELOG.md `[Unreleased]` updated with single batch entry per refinement-skill convention
- [x] `task check` passed (3020 passed, 1 xfailed)
- [x] All renders run (`task roadmap:render` + `task project:render`) once at end of batch per #638
- [x] No skill, rule, or source code changes (lifecycle + renders only)
- [x] Refs (not Closes) used for issue cross-references; nothing should auto-close

## Refs

#136 #140 #151 #163 #233 #689 #704 #733 #734 #737 #738 #739 #740 #741 #742

## Conversation

https://app.warp.dev/conversation/e467d16f-741a-497a-8ec8-04ee49add649
