### PR TITLE
chore(deps): bump pytest 9.0.3 and pygments 2.20.0 (Dependabot security patches)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **chore(deps): bump pytest 9.0.2 -> 9.0.3 and pygments 2.19.2 -> 2.20.0** (Dependabot alerts #4 and #3): Closes two open security alerts on `uv.lock`. (1) `pytest` GHSA-6w46-j5rx-g56g / CVE-2025-71176 (medium) -- vulnerable tmpdir handling on UNIX where pytest <9.0.3 relies on `/tmp/pytest-of-{user}` directories that allow local users to cause denial of service or possibly gain privileges; bump to 9.0.3 (first patched). (2) `pygments` GHSA-5239-wwwm-4pmq / CVE-2026-4539 (low) -- ReDoS in `AdlLexer` via inefficient regex in `pygments/lexers/archetype.py`; bump to 2.20.0 (first patched). Both are dev-group dependencies (pygments transitive via pytest); `task check` passes (3020 passed, 1 xfailed) post-upgrade.
 - **chore(vbrief): refinement session 2026-04-29** -- ran a bulk refinement pass. Ingested + activated 5 issues (#704, #733, #734, #737, #741), activated existing pending #163, closed #136 as resolved-upstream, closed #140 as superseded by #689 + `deft-directive-sync`, closed #151 via decomposition into #738/#739/#740, applied the `epic` label to #233, filed #742 as the ADR-001 tracking issue for the vBRIEF-as-master discussion (awaiting review; no follow-on issues filed), and re-rendered `ROADMAP.md` plus `vbrief/PROJECT-DEFINITION.vbrief.json`.
 
 ### Fixed

--- a/uv.lock
+++ b/uv.lock
@@ -359,16 +359,16 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -377,9 +377,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes the two open Dependabot alerts on `master`. Both packages are dev-group dependencies in `uv.lock` (no production runtime impact).

## Changes

| Package | Before | After | Severity | CVE | GHSA |
|---|---|---|---|---|---|
| pytest | 9.0.2 | **9.0.3** | medium | CVE-2025-71176 | GHSA-6w46-j5rx-g56g |
| pygments | 2.19.2 | **2.20.0** | low | CVE-2026-4539 | GHSA-5239-wwwm-4pmq |

### pytest (medium)

> pytest through 9.0.2 on UNIX relies on directories with the `/tmp/pytest-of-{user}` name pattern, which allows local users to cause a denial of service or possibly gain privileges.

Fixed in 9.0.3.

### pygments (low)

> A security flaw has been discovered in pygments before 2.20.0. The impacted element is the function `AdlLexer` of the file `pygments/lexers/archetype.py`. The manipulation results in inefficient regular expression complexity. The attack is only possible with local access.

Fixed in 2.20.0. Pygments is transitive via pytest in our dep graph.

## How

```bash
uv lock --upgrade-package pytest --upgrade-package pygments
```

Resolved by `uv` to the first-patched versions for both. No `pyproject.toml` constraint changes needed (existing `pytest>=7.4` accepts 9.0.3+).

## Validation

- `task check` passed: **3020 passed, 1 xfailed** (no test changes needed)
- Lockfile delta: 12 lines in `uv.lock` (version + sha256 for each package)
- No source code touched

## Checklist

- [x] CHANGELOG.md `[Unreleased]` entry added (single entry, both packages)
- [x] `task check` passes post-upgrade
- [x] No skill, rule, or source code changes (lockfile + dev-deps only)
- [x] Refs (not Closes) used; Dependabot will auto-close its alerts when this lands on master

## Refs

GitHub Dependabot alerts (private to repo admins):
- https://github.com/deftai/directive/security/dependabot/4 (pytest)
- https://github.com/deftai/directive/security/dependabot/3 (pygments)
