### PR TITLE
chore(vbrief): complete #801 and #810 scopes -- pending -> completed

### DIFF
--- a/vbrief/completed/2026-05-01-801-periodic-remote-version-probe-prompt-on-new-upstream-tags.vbrief.json
+++ b/vbrief/completed/2026-05-01-801-periodic-remote-version-probe-prompt-on-new-upstream-tags.vbrief.json
@@ -3,12 +3,12 @@
     "version": "0.6",
     "description": "Adoption blocker: directive has zero awareness of upstream releases. Add a periodic, read-only remote-version probe that runs `git ls-remote --tags` against the deft submodule's upstream, throttled to 24h per remote tag, and surfaces a single warn line when the local checkout is behind. Never auto-mutates project state -- write paths stay in cmd_upgrade / sync skill / task migrate:vbrief.",
     "created": "2026-05-01T19:04:00Z",
-    "updated": "2026-05-01T20:00:00Z"
+    "updated": "2026-05-01T23:35:54Z"
   },
   "plan": {
     "id": "801-periodic-remote-version-probe",
     "title": "Periodic remote-version probe: occasionally check upstream for new directive tags and prompt the user to update",
-    "status": "pending",
+    "status": "completed",
     "planRef": "#801",
     "narratives": {
       "Problem": "Directive currently has zero awareness of upstream releases. `_resolve_version()` (run lines 50-88) reads only local refs via `git describe --tags --abbrev=0`; `cmd_update` (run line 2614) is a stub that prints 'not yet implemented'; the upgrade gate in `_check_upgrade_gate` (#410) compares the project's vbrief/.deft-version marker against the in-process VERSION only -- it never asks 'is VERSION itself behind the remote?'; and the universal gate `cmd_gate` (#768) is intentionally read-only and offline. The deft submodule is only refreshed when the user explicitly runs skills/deft-directive-sync/SKILL.md Phase 2 (`git submodule update --remote --merge deft`), which most users will run rarely or never. Net effect: a consumer can sit at v0.18 indefinitely while v0.23 ships fixes (e.g. #768 stale-AGENTS.md), with no signal in any session that an upstream release exists. The recorded-vs-current gate cannot fire because both numbers are local. Velocity check (last 30 days, this repo): 6 minor releases in 8 days (v0.20.0, v0.20.1, v0.20.2, v0.21.0, v0.22.0, v0.23.0); commits per active day median around 9. A weekly notification cadence would silently swallow 3-5 release notifications per sprint -- justifying a 24h notification floor.",
@@ -176,6 +176,7 @@
         "type": "x-vbrief/related-doc",
         "title": "Sync skill Phase 2 -- the existing user-triggered remote refresh that this probe complements"
       }
-    ]
+    ],
+    "updated": "2026-05-01T23:35:54Z"
   }
 }

--- a/vbrief/completed/2026-05-01-810-implementation-intent-gate-prevent-unauthorized-agent-spawn.vbrief.json
+++ b/vbrief/completed/2026-05-01-810-implementation-intent-gate-prevent-unauthorized-agent-spawn.vbrief.json
@@ -3,12 +3,12 @@
     "version": "0.6",
     "description": "Bug: agents reading AGENTS.md infer implementation intent from lifecycle/branching/PR-process language and spawn code-writing sub-agents without explicit action-verb authorization. Fix is two layered changes: (1) structural enforcement via scripts/preflight_implementation.py + task vbrief:activate, requiring vBRIEFs to live in vbrief/active/ with status running before any implementation agent can spawn; (2) Implementation Intent Gate block in templates/agents-entry.md (managed-section, propagated by cmd_agents_refresh) plus repo-level AGENTS.md mirror.",
     "created": "2026-05-01T20:04:00Z",
-    "updated": "2026-05-01T20:04:00Z"
+    "updated": "2026-05-01T23:35:54Z"
   },
   "plan": {
     "id": "810-implementation-intent-gate",
     "title": "Implementation-intent inference is non-deterministic: enforce action-verb gate via preflight + AGENTS.md anti-pattern",
-    "status": "pending",
+    "status": "completed",
     "planRef": "#810",
     "narratives": {
       "Problem": "Agents reading AGENTS.md infer implementation intent from lifecycle, branching, or PR-process language and spawn code-writing sub-agents without explicit action-verb authorization. Reproduced in the #801 session: user said 'do full pr process to get it into master use poller agents not local loops' -- intent was scoping / scheduling guidance, but the orchestrator parsed 'full PR process' + 'poller agents' + 'not local loops' as authorization to invoke start_agent for implementation. None of the documented skill-routing keywords (build, implement, swarm, run agents) appeared in the user's message; the agent inferred them from workflow-shape vocabulary. Three enforcement-seam gaps make this honor-system: (1) AGENTS.md skill-routing is a positive grammar -- it lists trigger keywords for skills but does NOT codify 'absence of these keywords forbids implementation'; (2) Lifecycle folders carry semantic meaning (proposed -> pending -> active) but only skills/deft-directive-swarm/SKILL.md enforces the active/-required gate at Phase 0 Step 1; skills/deft-directive-build/SKILL.md does not refuse to operate against a pending/ vBRIEF; (3) plan.status enum has 'running' for 'in flight' but no gate logic refuses start_agent when status is 'pending'. Net failure mode: wasted sub-agent budget on unauthorized implementation, plus lifecycle-skip drift where pending/ items get implemented before the activation handoff that the swarm allocation contract expects.",
@@ -191,6 +191,7 @@
         "type": "x-vbrief/related-doc",
         "title": "Swarm skill -- Phase 0 Step 1 deduplicated against the new helper"
       }
-    ]
+    ],
+    "updated": "2026-05-01T23:35:54Z"
   }
 }


### PR DESCRIPTION
## Summary

Post-merge lifecycle hygiene for the two PRs landed in this session. Walks both vBRIEFs through `pending/` → `active/` → `completed/` via the framework's own `task vbrief:activate` and `task scope:complete` (dogfooded — exercises the new #810 lifecycle helpers).

- **#801** (PR #811): periodic remote-version probe with 24h-per-tag throttle.
- **#810** (PR #812): implementation-intent preflight gate + AGENTS.md anti-pattern.

Both vBRIEFs now in `vbrief/completed/` with `plan.status: completed` and `vBRIEFInfo.updated` bumped to current ISO 8601 UTC.

## Changes

- `vbrief/pending/2026-05-01-801-...vbrief.json` → `vbrief/completed/2026-05-01-801-...vbrief.json`
- `vbrief/pending/2026-05-01-810-...vbrief.json` → `vbrief/completed/2026-05-01-810-...vbrief.json`

Diff: 2 files renamed, 8 insertions / 6 deletions (status flip + timestamp bump only).

## Tests

No new tests — this is a metadata-only lifecycle move. Existing `tests/cli/test_vbrief_activate.py` + `tests/cli/test_scope_lifecycle.py` cover the move semantics.

## Checklist

- [x] Conventional Commits subject (`chore(vbrief): ...`).
- [x] No new functional code.
- [x] No CHANGELOG entry needed (lifecycle hygiene, not user-visible behavior).
- [x] Branch-protection hook passed.

## Refs

- Refs https://github.com/deftai/directive/issues/801
- Refs https://github.com/deftai/directive/issues/810
- Refs https://github.com/deftai/directive/pull/811 (the #801 merge)
- Refs https://github.com/deftai/directive/pull/812 (the #810 merge)
