### PR TITLE
chore(vbrief): complete Phase 1 -- Fix Now cohort (9 briefs -> completed/)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,20 +5,6 @@
 
 # Roadmap
 
-## Phase 1 -- Fix Now
-
-Urgent fixes to land ahead of broader roadmap work -- adoption blockers and bugs that block consumer adoption or successful first-session UX.
-
-- **#791** -- run.bat: resolve `run` against %~dp0 instead of CWD (Windows)
-- **#792** -- cmd_doctor: add uv check; replace pre-v0.20 expected_dirs with v0.20+ layout
-- **#793** -- Add task migrate:preflight; have migrate:vbrief self-invoke it
-- **#794** -- Document AGENTS.md managed-section legacy migration in UPGRADING.md
-- **#798** -- Detect PS 5.1 non-ASCII round-trip corruption in pre-commit + task check (deterministic tier per [AXIOM])
-- **#784** -- fix(scripts/release.py): pre-flight should verify release tag is available before state mutation
-- **#796** -- Review-cycle dual-source fetch can miss late-arriving bot reviews
-- **#800** -- swarm SKILL: prohibit `git checkout` in a worktree another agent owns (post-merge cleanup overreach)
-- **#814** -- scripts/preflight_branch.py crashes with UnicodeEncodeError on Windows (cp1252) -- blocks every commit
-
 ## Phase 2
 
 Near-up structural priority -- post-cutover stabilization, structural unblockers (items gating many others), and cross-cutting items whose effect spans multiple skills, strategies, or files.
@@ -375,6 +361,15 @@ Larger feature work -- only after issues are resolved and content is stable.
 - **#767** -- feat(framework,skills): add Discuss + Back as canonical numbered options in all deterministic-mode questions -- `[completed]`
 - **#768** -- Universal upgrade gate: stale-AGENTS.md consumers silently follow obsolete instructions -- `[completed]`
 - **#771** -- release-core: keep pyproject version truthful and define semver -> PEP 440 normalization -- `[completed]`
+- **#791** -- run.bat: resolve `run` against %~dp0 instead of CWD (Windows) -- `[completed]`
+- **#792** -- cmd_doctor: add uv check; replace pre-v0.20 expected_dirs with v0.20+ layout -- `[completed]`
+- **#793** -- Add task migrate:preflight; have migrate:vbrief self-invoke it -- `[completed]`
+- **#794** -- Document AGENTS.md managed-section legacy migration in UPGRADING.md -- `[completed]`
+- **#798** -- Detect PS 5.1 non-ASCII round-trip corruption in pre-commit + task check (deterministic tier per [AXIOM]) -- `[completed]`
 - **#801** -- Periodic remote-version probe: occasionally check upstream for new directive tags and prompt the user to update -- `[completed]`
 - **#810** -- Implementation-intent inference is non-deterministic: enforce action-verb gate via preflight + AGENTS.md anti-pattern -- `[completed]`
+- **#784** -- fix(scripts/release.py): pre-flight should verify release tag is available before state mutation -- `[completed]`
+- **#796** -- Review-cycle dual-source fetch can miss late-arriving bot reviews -- `[completed]`
+- **#800** -- swarm SKILL: prohibit `git checkout` in a worktree another agent owns (post-merge cleanup overreach) -- `[completed]`
+- **#814** -- scripts/preflight_branch.py crashes with UnicodeEncodeError on Windows (cp1252) -- blocks every commit -- `[completed]`
 

--- a/tests/content/test_swarm_skill.py
+++ b/tests/content/test_swarm_skill.py
@@ -70,7 +70,8 @@ def _phase6_step3_block(text: str) -> str:
 # contract while preserving the rule's intent.
 _STEP3_NO_CHECKOUT_TOKENS = (
     # The MUST NOT marker MUST be the canonical U+2297 glyph, not the cp1252
-    # mojibake 'Γèù' (#796 / #800 pre-PR fix-up trail).
+    # mojibake form (encoded here as escape sequences to keep this file
+    # encoding-gate clean per #798).
     "\u2297",
     # Action prohibited.
     "git checkout",
@@ -122,10 +123,12 @@ def test_swarm_phase6_step3_no_checkout_rule_present(token: str) -> None:
 def test_swarm_phase6_step3_no_checkout_rule_uses_canonical_glyph() -> None:
     """The MUST NOT marker MUST be U+2297 (\u2297), not the cp1252 mojibake."""
     block = _phase6_step3_block(_read_swarm())
-    # Defence-in-depth: the cp1252 round-trip mojibake of \u2297 ('\u0393\u00e8\u00f9'
-    # = 'Γèù') would have shipped if a swarm agent followed the corrupted
-    # vbrief verbatim. This pre-PR fix-up trail is documented in the
-    # CHANGELOG entry referencing #796 / #800.
+    # Defence-in-depth: the cp1252 round-trip mojibake of \u2297 (the
+    # three-codepoint sequence \u0393\u00e8\u00f9) would have shipped if a
+    # swarm agent followed the corrupted vbrief verbatim. This pre-PR
+    # fix-up trail is documented in the CHANGELOG entry referencing
+    # #796 / #800. The literal mojibake form is intentionally NOT written
+    # here to keep this file clean against the #798 encoding gate.
     assert "\u0393\u00e8\u00f9" not in block, (
         f"{_SWARM_PATH}: Phase 6 Step 3 contains cp1252 mojibake "
         f"('\u0393\u00e8\u00f9') instead of canonical \u2297 (U+2297)"

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -2,7 +2,7 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Project definition -- synthesized gestalt of the project.",
-    "updated": "2026-05-03T02:25:07Z"
+    "updated": "2026-05-03T04:38:25Z"
   },
   "plan": {
     "title": "PROJECT-DEFINITION",
@@ -888,275 +888,6 @@
               "uri": "https://github.com/deftai/directive/issues/762",
               "type": "x-vbrief/github-issue",
               "title": "Issue #762: feat(vbrief): centralize phase taxonomy in PROJECT-DEFINITION.vbrief.json; renderer reads from there"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-01-791-runbat-resolves-un-against-cwd-instead-of-dp0-windows-path-b",
-        "title": "run.bat: resolve `run` against %~dp0 instead of CWD (Windows)",
-        "status": "pending",
-        "metadata": {
-          "source_path": "pending/2026-05-01-791-runbat-resolves-un-against-cwd-instead-of-dp0-windows-path-b.vbrief.json",
-          "lifecycle_folder": "pending",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/791",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #791: run.bat resolves `run` against CWD instead of %~dp0 (Windows path bug)"
-            },
-            {
-              "uri": "main.md#publishing-deft-tasks-in-your-project-root",
-              "type": "x-vbrief/related-doc",
-              "title": "Related: same class of framework-relative path resolution that the consumer Taskfile include solves (already documented)"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-01-792-cmd-doctor-missing-uv-check-expected-dirs-lists-pre-v020-dir",
-        "title": "cmd_doctor: add uv check; replace pre-v0.20 expected_dirs with v0.20+ layout",
-        "status": "pending",
-        "metadata": {
-          "source_path": "pending/2026-05-01-792-cmd-doctor-missing-uv-check-expected-dirs-lists-pre-v020-dir.vbrief.json",
-          "lifecycle_folder": "pending",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/792",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #792: cmd_doctor missing uv check; expected_dirs lists pre-v0.20 directories"
-            },
-            {
-              "uri": "skills/deft-directive-setup/SKILL.md",
-              "type": "x-vbrief/related-doc",
-              "title": "Environment Preflight: the agent-side uv check to mirror"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/793",
-              "type": "x-vbrief/related-issue",
-              "title": "Issue #793 (related): task migrate:preflight should consume the same uv-detection helper introduced here"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-01-793-add-task-migratepreflight-aggregate-have-migratevbrief-self",
-        "title": "Add task migrate:preflight; have migrate:vbrief self-invoke it",
-        "status": "pending",
-        "metadata": {
-          "source_path": "pending/2026-05-01-793-add-task-migratepreflight-aggregate-have-migratevbrief-self.vbrief.json",
-          "lifecycle_folder": "pending",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/793",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #793: Add task migrate:preflight aggregate; have migrate:vbrief self-invoke it"
-            },
-            {
-              "uri": "skills/deft-directive-setup/SKILL.md",
-              "type": "x-vbrief/related-doc",
-              "title": "Environment Preflight: the agent-side preflight contract this task reifies"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/792",
-              "type": "x-vbrief/related-issue",
-              "title": "Issue #792 (soft-dep): cmd_doctor uv check; share uv-detection helper if #792 lands first"
-            },
-            {
-              "uri": "tasks/migrate.yml",
-              "type": "x-vbrief/related-doc",
-              "title": "The Taskfile surface to extend"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-01-794-document-agentsmd-managed-section-legacy-migration-in-upgrad",
-        "title": "Document AGENTS.md managed-section legacy migration in UPGRADING.md",
-        "status": "pending",
-        "metadata": {
-          "source_path": "pending/2026-05-01-794-document-agentsmd-managed-section-legacy-migration-in-upgrad.vbrief.json",
-          "lifecycle_folder": "pending",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/794",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #794: Document AGENTS.md managed-section legacy migration in UPGRADING.md"
-            },
-            {
-              "uri": "templates/agents-entry.md",
-              "type": "x-vbrief/related-doc",
-              "title": "The rendered managed-section template (preview link target)"
-            },
-            {
-              "uri": "QUICK-START.md",
-              "type": "x-vbrief/related-doc",
-              "title": "Case G: agent-prescriptive coverage of the same scenario; cross-link target"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-01-798-detect-ps-51-non-ascii-round-trip-corruption-in-pre-commit-t",
-        "title": "Detect PS 5.1 non-ASCII round-trip corruption in pre-commit + task check (deterministic tier per [AXIOM])",
-        "status": "pending",
-        "metadata": {
-          "source_path": "pending/2026-05-01-798-detect-ps-51-non-ascii-round-trip-corruption-in-pre-commit-t.vbrief.json",
-          "lifecycle_folder": "pending",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/798",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #798: Detect PS 5.1 non-ASCII round-trip corruption in pre-commit + task check (4th recurrence)"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/pull/795",
-              "type": "x-vbrief/github-pr",
-              "title": "PR #795 -- 4th recurrence record (CHANGELOG.md mojibake during P2 batch fix)"
-            },
-            {
-              "uri": "AGENTS.md",
-              "type": "x-vbrief/related-doc",
-              "title": "PowerShell section: the prose tier rule this proposal elevates to deterministic"
-            },
-            {
-              "uri": "main.md",
-              "type": "x-vbrief/related-doc",
-              "title": "Rule Authority [AXIOM] -- the hierarchy this proposal climbs"
-            },
-            {
-              "uri": "scripts/preflight_branch.py",
-              "type": "x-vbrief/related-doc",
-              "title": "Sibling deterministic gate (#747) -- shape model for the new scripts/verify_encoding.py"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-03-784-fixscriptsreleasepy-pre-flight-should-verify-release-tag-is",
-        "title": "fix(scripts/release.py): pre-flight should verify release tag is available before state mutation",
-        "status": "pending",
-        "metadata": {
-          "source_path": "pending/2026-05-03-784-fixscriptsreleasepy-pre-flight-should-verify-release-tag-is.vbrief.json",
-          "lifecycle_folder": "pending",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/784",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #784: fix(scripts/release.py): pre-flight should verify release tag is available before state mutation"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/734",
-              "type": "x-vbrief/related-issue",
-              "title": "Issue #734 (sibling pattern): vBRIEF lifecycle sync gate -- precedent for adding a pre-flight step that refuses before state mutation"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/716",
-              "type": "x-vbrief/related-issue",
-              "title": "Issue #716: release safety hardening (default-draft, verify-isDraft) -- companion publish-side gate"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/74",
-              "type": "x-vbrief/related-issue",
-              "title": "Issue #74: release pipeline parent"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-03-796-review-cycle-dual-source-fetch-can-miss-late-arriving-bot-re",
-        "title": "Review-cycle dual-source fetch can miss late-arriving bot reviews",
-        "status": "pending",
-        "metadata": {
-          "source_path": "pending/2026-05-03-796-review-cycle-dual-source-fetch-can-miss-late-arriving-bot-re.vbrief.json",
-          "lifecycle_folder": "pending",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/796",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #796: Review-cycle dual-source fetch can miss late-arriving bot reviews"
-            },
-            {
-              "uri": "skills/deft-directive-review-cycle/SKILL.md",
-              "type": "x-vbrief/related-doc",
-              "title": "Phase 2 Step 1 (Fetch ALL bot comments) -- the surface this PR extends"
-            },
-            {
-              "uri": "templates/swarm-greptile-poller-prompt.md",
-              "type": "x-vbrief/related-doc",
-              "title": "Poller template -- already handles the late-arrival case in its loop body; no-op for this work"
-            },
-            {
-              "uri": "meta/lessons.md",
-              "type": "x-vbrief/related-doc",
-              "title": "PR Review Process (2026-03) -- precedent lesson on dual-source fetching + Comments Outside Diff"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-03-800-swarm-skill-prohibit-git-checkout-in-a-worktree-another-agen",
-        "title": "swarm SKILL: prohibit `git checkout` in a worktree another agent owns (post-merge cleanup overreach)",
-        "status": "pending",
-        "metadata": {
-          "source_path": "pending/2026-05-03-800-swarm-skill-prohibit-git-checkout-in-a-worktree-another-agen.vbrief.json",
-          "lifecycle_folder": "pending",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/800",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #800: swarm SKILL prohibit git checkout in a worktree another agent owns (post-merge cleanup overreach)"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/727",
-              "type": "x-vbrief/related-issue",
-              "title": "Issue #727 (companion): Sub-Agent Role Separation -- this work extends the same boundary discipline to worktree HEAD operations"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/pull/797",
-              "type": "x-vbrief/github-pr",
-              "title": "PR #797 -- recurrence record (Agent B's post-merge `cd ...; git checkout master --quiet` against Agent A's worktree)"
-            },
-            {
-              "uri": "skills/deft-directive-swarm/SKILL.md",
-              "type": "x-vbrief/related-doc",
-              "title": "Phase 6 Step 3 (Update Master) -- the surface this PR extends"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-03-814-scriptspreflight-branchpy-crashes-with-unicodeencodeerror-on",
-        "title": "scripts/preflight_branch.py crashes with UnicodeEncodeError on Windows (cp1252) -- blocks every commit",
-        "status": "pending",
-        "metadata": {
-          "source_path": "pending/2026-05-03-814-scriptspreflight-branchpy-crashes-with-unicodeencodeerror-on.vbrief.json",
-          "lifecycle_folder": "pending",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/814",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #814: scripts/preflight_branch.py crashes with UnicodeEncodeError on Windows (cp1252) when printing the success glyph -- blocks every commit"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/747",
-              "type": "x-vbrief/related-issue",
-              "title": "Issue #747: detection-bound branch gate -- the surface this affects"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/810",
-              "type": "x-vbrief/related-issue",
-              "title": "Issue #810: implementation-intent gate -- the session that surfaced this; the chore commit was blocked until PYTHONIOENCODING=utf-8 was applied"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/768",
-              "type": "x-vbrief/related-issue",
-              "title": "Issue #768: cmd_agents_refresh -- another deft-managed surface that prints non-ASCII; audit Change 2 should include it"
-            },
-            {
-              "uri": "scripts/preflight_branch.py",
-              "type": "x-vbrief/related-doc",
-              "title": "The script to fix"
             }
           ]
         }
@@ -5863,6 +5594,146 @@
         }
       },
       {
+        "id": "2026-05-01-791-runbat-resolves-un-against-cwd-instead-of-dp0-windows-path-b",
+        "title": "run.bat: resolve `run` against %~dp0 instead of CWD (Windows)",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-01-791-runbat-resolves-un-against-cwd-instead-of-dp0-windows-path-b.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/791",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #791: run.bat resolves `run` against CWD instead of %~dp0 (Windows path bug)"
+            },
+            {
+              "uri": "main.md#publishing-deft-tasks-in-your-project-root",
+              "type": "x-vbrief/related-doc",
+              "title": "Related: same class of framework-relative path resolution that the consumer Taskfile include solves (already documented)"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-01-792-cmd-doctor-missing-uv-check-expected-dirs-lists-pre-v020-dir",
+        "title": "cmd_doctor: add uv check; replace pre-v0.20 expected_dirs with v0.20+ layout",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-01-792-cmd-doctor-missing-uv-check-expected-dirs-lists-pre-v020-dir.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/792",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #792: cmd_doctor missing uv check; expected_dirs lists pre-v0.20 directories"
+            },
+            {
+              "uri": "skills/deft-directive-setup/SKILL.md",
+              "type": "x-vbrief/related-doc",
+              "title": "Environment Preflight: the agent-side uv check to mirror"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/793",
+              "type": "x-vbrief/related-issue",
+              "title": "Issue #793 (related): task migrate:preflight should consume the same uv-detection helper introduced here"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-01-793-add-task-migratepreflight-aggregate-have-migratevbrief-self",
+        "title": "Add task migrate:preflight; have migrate:vbrief self-invoke it",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-01-793-add-task-migratepreflight-aggregate-have-migratevbrief-self.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/793",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #793: Add task migrate:preflight aggregate; have migrate:vbrief self-invoke it"
+            },
+            {
+              "uri": "skills/deft-directive-setup/SKILL.md",
+              "type": "x-vbrief/related-doc",
+              "title": "Environment Preflight: the agent-side preflight contract this task reifies"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/792",
+              "type": "x-vbrief/related-issue",
+              "title": "Issue #792 (soft-dep): cmd_doctor uv check; share uv-detection helper if #792 lands first"
+            },
+            {
+              "uri": "tasks/migrate.yml",
+              "type": "x-vbrief/related-doc",
+              "title": "The Taskfile surface to extend"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-01-794-document-agentsmd-managed-section-legacy-migration-in-upgrad",
+        "title": "Document AGENTS.md managed-section legacy migration in UPGRADING.md",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-01-794-document-agentsmd-managed-section-legacy-migration-in-upgrad.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/794",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #794: Document AGENTS.md managed-section legacy migration in UPGRADING.md"
+            },
+            {
+              "uri": "templates/agents-entry.md",
+              "type": "x-vbrief/related-doc",
+              "title": "The rendered managed-section template (preview link target)"
+            },
+            {
+              "uri": "QUICK-START.md",
+              "type": "x-vbrief/related-doc",
+              "title": "Case G: agent-prescriptive coverage of the same scenario; cross-link target"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-01-798-detect-ps-51-non-ascii-round-trip-corruption-in-pre-commit-t",
+        "title": "Detect PS 5.1 non-ASCII round-trip corruption in pre-commit + task check (deterministic tier per [AXIOM])",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-01-798-detect-ps-51-non-ascii-round-trip-corruption-in-pre-commit-t.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/798",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #798: Detect PS 5.1 non-ASCII round-trip corruption in pre-commit + task check (4th recurrence)"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/pull/795",
+              "type": "x-vbrief/github-pr",
+              "title": "PR #795 -- 4th recurrence record (CHANGELOG.md mojibake during P2 batch fix)"
+            },
+            {
+              "uri": "AGENTS.md",
+              "type": "x-vbrief/related-doc",
+              "title": "PowerShell section: the prose tier rule this proposal elevates to deterministic"
+            },
+            {
+              "uri": "main.md",
+              "type": "x-vbrief/related-doc",
+              "title": "Rule Authority [AXIOM] -- the hierarchy this proposal climbs"
+            },
+            {
+              "uri": "scripts/preflight_branch.py",
+              "type": "x-vbrief/related-doc",
+              "title": "Sibling deterministic gate (#747) -- shape model for the new scripts/verify_encoding.py"
+            }
+          ]
+        }
+      },
+      {
         "id": "2026-05-01-801-periodic-remote-version-probe-prompt-on-new-upstream-tags",
         "title": "Periodic remote-version probe: occasionally check upstream for new directive tags and prompt the user to update",
         "status": "completed",
@@ -5938,10 +5809,140 @@
             }
           ]
         }
+      },
+      {
+        "id": "2026-05-03-784-fixscriptsreleasepy-pre-flight-should-verify-release-tag-is",
+        "title": "fix(scripts/release.py): pre-flight should verify release tag is available before state mutation",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-03-784-fixscriptsreleasepy-pre-flight-should-verify-release-tag-is.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/784",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #784: fix(scripts/release.py): pre-flight should verify release tag is available before state mutation"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/734",
+              "type": "x-vbrief/related-issue",
+              "title": "Issue #734 (sibling pattern): vBRIEF lifecycle sync gate -- precedent for adding a pre-flight step that refuses before state mutation"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/716",
+              "type": "x-vbrief/related-issue",
+              "title": "Issue #716: release safety hardening (default-draft, verify-isDraft) -- companion publish-side gate"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/74",
+              "type": "x-vbrief/related-issue",
+              "title": "Issue #74: release pipeline parent"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-03-796-review-cycle-dual-source-fetch-can-miss-late-arriving-bot-re",
+        "title": "Review-cycle dual-source fetch can miss late-arriving bot reviews",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-03-796-review-cycle-dual-source-fetch-can-miss-late-arriving-bot-re.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/796",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #796: Review-cycle dual-source fetch can miss late-arriving bot reviews"
+            },
+            {
+              "uri": "skills/deft-directive-review-cycle/SKILL.md",
+              "type": "x-vbrief/related-doc",
+              "title": "Phase 2 Step 1 (Fetch ALL bot comments) -- the surface this PR extends"
+            },
+            {
+              "uri": "templates/swarm-greptile-poller-prompt.md",
+              "type": "x-vbrief/related-doc",
+              "title": "Poller template -- already handles the late-arrival case in its loop body; no-op for this work"
+            },
+            {
+              "uri": "meta/lessons.md",
+              "type": "x-vbrief/related-doc",
+              "title": "PR Review Process (2026-03) -- precedent lesson on dual-source fetching + Comments Outside Diff"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-03-800-swarm-skill-prohibit-git-checkout-in-a-worktree-another-agen",
+        "title": "swarm SKILL: prohibit `git checkout` in a worktree another agent owns (post-merge cleanup overreach)",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-03-800-swarm-skill-prohibit-git-checkout-in-a-worktree-another-agen.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/800",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #800: swarm SKILL prohibit git checkout in a worktree another agent owns (post-merge cleanup overreach)"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/727",
+              "type": "x-vbrief/related-issue",
+              "title": "Issue #727 (companion): Sub-Agent Role Separation -- this work extends the same boundary discipline to worktree HEAD operations"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/pull/797",
+              "type": "x-vbrief/github-pr",
+              "title": "PR #797 -- recurrence record (Agent B's post-merge `cd ...; git checkout master --quiet` against Agent A's worktree)"
+            },
+            {
+              "uri": "skills/deft-directive-swarm/SKILL.md",
+              "type": "x-vbrief/related-doc",
+              "title": "Phase 6 Step 3 (Update Master) -- the surface this PR extends"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-03-814-scriptspreflight-branchpy-crashes-with-unicodeencodeerror-on",
+        "title": "scripts/preflight_branch.py crashes with UnicodeEncodeError on Windows (cp1252) -- blocks every commit",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-03-814-scriptspreflight-branchpy-crashes-with-unicodeencodeerror-on.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/814",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #814: scripts/preflight_branch.py crashes with UnicodeEncodeError on Windows (cp1252) when printing the success glyph -- blocks every commit"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/747",
+              "type": "x-vbrief/related-issue",
+              "title": "Issue #747: detection-bound branch gate -- the surface this affects"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/810",
+              "type": "x-vbrief/related-issue",
+              "title": "Issue #810: implementation-intent gate -- the session that surfaced this; the chore commit was blocked until PYTHONIOENCODING=utf-8 was applied"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/768",
+              "type": "x-vbrief/related-issue",
+              "title": "Issue #768: cmd_agents_refresh -- another deft-managed surface that prints non-ASCII; audit Change 2 should include it"
+            },
+            {
+              "uri": "scripts/preflight_branch.py",
+              "type": "x-vbrief/related-doc",
+              "title": "The script to fix"
+            }
+          ]
+        }
       }
     ],
     "metadata": {
       "staleness_flags": [
+        "Narrative 'LegacyArtifacts' may be stale: completed scope 'Document AGENTS.md managed-section legacy migration in UPGRADING.md' shares topics (legacy)",
         "Narrative 'LegacyArtifacts' may be stale: completed scope 'Project bootstrap: purge stale legacy path references across 42 files; add strategy stubs (rapid.md, enterprise.md); add docs/getting-started.md stub' shares topics (legacy)",
         "Narrative 'LegacyArtifacts' may be stale: completed scope 'SKILL.md platform entry point is entirely pre-cutover -- references old skill names and deprecated artifacts' shares topics (artifacts)",
         "Narrative 'LegacyArtifacts' may be stale: completed scope 'Stale cross-references to legacy paths' shares topics (legacy)",

--- a/vbrief/completed/2026-05-01-791-runbat-resolves-un-against-cwd-instead-of-dp0-windows-path-b.vbrief.json
+++ b/vbrief/completed/2026-05-01-791-runbat-resolves-un-against-cwd-instead-of-dp0-windows-path-b.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "791-runbat-cwd-resolution-bug",
     "title": "run.bat: resolve `run` against %~dp0 instead of CWD (Windows)",
-    "status": "running",
+    "status": "completed",
     "planRef": "#791",
     "narratives": {
       "Problem": "run.bat:25 reads `python.exe run %*`. The `run` token is an unqualified relative path; Windows resolves it against the current working directory of the caller, not the directory of run.bat. Consumers who install deft as `./deft/` and follow the documented `..\\deft\\run upgrade` invocation from their project root therefore see python.exe fail to find a script named `run`. Workaround in field use: `python.exe \"<full path>\\deft\\run\" upgrade`.",
@@ -101,6 +101,6 @@
         "title": "Related: same class of framework-relative path resolution that the consumer Taskfile include solves (already documented)"
       }
     ],
-    "updated": "2026-05-03T01:41:27Z"
+    "updated": "2026-05-03T04:38:15Z"
   }
 }

--- a/vbrief/completed/2026-05-01-792-cmd-doctor-missing-uv-check-expected-dirs-lists-pre-v020-dir.vbrief.json
+++ b/vbrief/completed/2026-05-01-792-cmd-doctor-missing-uv-check-expected-dirs-lists-pre-v020-dir.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "792-cmd-doctor-uv-and-stale-dirs",
     "title": "cmd_doctor: add uv check; replace pre-v0.20 expected_dirs with v0.20+ layout",
-    "status": "running",
+    "status": "completed",
     "planRef": "#792",
     "narratives": {
       "Problem": "Two defects in run::cmd_doctor (run lines 2563-2612). (1) Missing uv check: every deft task script runs via `uv run python ...` (tasks/migrate.yml:34, tasks/issue.yml:27, etc.), making uv a hard runtime dependency. cmd_doctor checks task / git / python3 / go / node but not uv, so a fresh-machine user gets a green report and then an opaque `uv: command not found` failure as soon as they run task migrate:vbrief. (2) Stale expected_dirs: the list at run line 2596 includes pre-v0.20 directories core/, interfaces/, tools/, swarm/, meta/ that were removed during the vBRIEF cutover. On a clean v0.23 checkout cmd_doctor warns 'Missing directory: <name>/' for each, burying any real signal. The agent-driven setup skill already implements the right uv check (skills/deft-directive-setup/SKILL.md::Environment Preflight); cmd_doctor must mirror it.",
@@ -132,6 +132,6 @@
         "title": "Issue #793 (related): task migrate:preflight should consume the same uv-detection helper introduced here"
       }
     ],
-    "updated": "2026-05-03T01:41:28Z"
+    "updated": "2026-05-03T04:38:17Z"
   }
 }

--- a/vbrief/completed/2026-05-01-793-add-task-migratepreflight-aggregate-have-migratevbrief-self.vbrief.json
+++ b/vbrief/completed/2026-05-01-793-add-task-migratepreflight-aggregate-have-migratevbrief-self.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "793-task-migrate-preflight-aggregate",
     "title": "Add task migrate:preflight; have migrate:vbrief self-invoke it",
-    "status": "running",
+    "status": "completed",
     "planRef": "#793",
     "narratives": {
       "Problem": "The pre-cutover migration preflight (task resolvability, uv on PATH, migrate_vbrief.py present) is currently prescribed only on the agent-driven path (QUICK-START.md Step H.2; skills/deft-directive-setup/SKILL.md Environment Preflight). A user who follows main.md Migrating from pre-v0.20 and runs `task migrate:vbrief` directly gets none of those checks: failures surface as raw subprocess errors (uv not found, FileNotFoundError) with no remediation pointer. This is an adoption blocker for any non-agent entry path (CI runs, scripted upgrades, ops engineers).",
@@ -147,6 +147,6 @@
         "title": "The Taskfile surface to extend"
       }
     ],
-    "updated": "2026-05-03T01:41:28Z"
+    "updated": "2026-05-03T04:38:17Z"
   }
 }

--- a/vbrief/completed/2026-05-01-794-document-agentsmd-managed-section-legacy-migration-in-upgrad.vbrief.json
+++ b/vbrief/completed/2026-05-01-794-document-agentsmd-managed-section-legacy-migration-in-upgrad.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "794-upgrading-md-agents-md-legacy-contract",
     "title": "Document AGENTS.md managed-section legacy migration in UPGRADING.md",
-    "status": "running",
+    "status": "completed",
     "planRef": "#794",
     "narratives": {
       "Problem": "When a consumer's AGENTS.md predates the <!-- deft:managed-section v1 --> markers, deft/run upgrade performs a one-time legacy migration (run::_wrap_legacy_in_markers, line ~1073; run::_agents_refresh_plan state=='missing' branch, line ~1131): existing content is preserved verbatim above the rendered managed section. Subsequent upgrades then become sentinel-only byte-replaces. The behavior is correct, but it is not documented in any user-facing surface. Risk-averse consumers reviewing the upgrade flow before running it cannot find the contract for what `run upgrade` will and will not modify. QUICK-START Case G covers the same scenario in agent-prescriptive terms but not as a long-term human-readable contract.",
@@ -124,6 +124,6 @@
         "title": "Case G: agent-prescriptive coverage of the same scenario; cross-link target"
       }
     ],
-    "updated": "2026-05-03T01:41:28Z"
+    "updated": "2026-05-03T04:38:15Z"
   }
 }

--- a/vbrief/completed/2026-05-01-798-detect-ps-51-non-ascii-round-trip-corruption-in-pre-commit-t.vbrief.json
+++ b/vbrief/completed/2026-05-01-798-detect-ps-51-non-ascii-round-trip-corruption-in-pre-commit-t.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "798-ps51-encoding-gate",
     "title": "Detect PS 5.1 non-ASCII round-trip corruption in pre-commit + task check (deterministic tier per [AXIOM])",
-    "status": "running",
+    "status": "completed",
     "planRef": "#798",
     "narratives": {
       "Problem": "PowerShell 5.1 (the default Windows PowerShell shipped on every Win10/11 install) silently corrupts non-ASCII content during read+write round-trips even when the write side specifies UTF-8 explicitly. Get-Content -Raw decodes via the active codepage (typically CP1252) on the READ side; the corruption is introduced before any 'safe write' can preserve the bytes. Three prior recurrences are recorded (#236 t1.11.1, #240 t1.11.2, #283 t1.20.1) and a fourth happened on PR #795 (CHANGELOG.md mojibake during P2 batch fix). The rule is encoded at the prose tier (personal rule + AGENTS.md PowerShell section + lessons.md cross-references) but per main.md Rule Authority [AXIOM] (deterministic > Taskfile > vBRIEF > RFC2119 > prose) the recurrence pattern most likely to bite a Windows consumer in their first session is at the WEAKEST tier with NO deterministic gate.",
@@ -161,6 +161,6 @@
         "title": "Sibling deterministic gate (#747) -- shape model for the new scripts/verify_encoding.py"
       }
     ],
-    "updated": "2026-05-03T01:41:28Z"
+    "updated": "2026-05-03T04:38:17Z"
   }
 }

--- a/vbrief/completed/2026-05-03-784-fixscriptsreleasepy-pre-flight-should-verify-release-tag-is.vbrief.json
+++ b/vbrief/completed/2026-05-03-784-fixscriptsreleasepy-pre-flight-should-verify-release-tag-is.vbrief.json
@@ -7,7 +7,7 @@
   },
   "plan": {
     "title": "fix(scripts/release.py): pre-flight should verify release tag is available before state mutation",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Problem": "scripts/release.py invokes `git tag v<version>` at Step 9 of a 12-step pipeline. By that point Steps 1-8 have already mutated state: CHANGELOG promoted to `[<version>]`, ROADMAP regenerated, pyproject.toml + uv.lock synced to the new version, dist/deft-<version>.zip built, and a `chore(release): v<version>` commit made locally. A duplicate-tag failure at Step 9 leaves an unpushed wrong-version commit on master with orphaned build artifacts; recovery requires `git reset --hard` (which AGENTS.md SCM rules forbid without explicit permission). Surfaced 2026-05-01 during the v0.23.0 release attempt where the operator typed `0.22.0` (the 12-hour-old prior release) and the pipeline ran 8 steps before failing.",
       "Overview": "Add a new `[X/N] Pre-flight tag availability` step to release.py Phase 1 (pre-flight), placed before any state mutation. Check three surfaces: local tag (`git tag -l`), remote tag (`git ls-remote --tags origin`), and GitHub release (`gh release view --repo`). Read-only; safe on dry-run; produces actionable recovery message naming the conflict source.",
@@ -137,7 +137,7 @@
         "pr_title_suggestion": "fix(scripts/release.py): verify release tag is available before state mutation (#784)"
       }
     },
-    "updated": "2026-05-03T01:53:52Z",
+    "updated": "2026-05-03T04:38:18Z",
     "id": "784-release-preflight-tag-availability",
     "planRef": "#784"
   }

--- a/vbrief/completed/2026-05-03-796-review-cycle-dual-source-fetch-can-miss-late-arriving-bot-re.vbrief.json
+++ b/vbrief/completed/2026-05-03-796-review-cycle-dual-source-fetch-can-miss-late-arriving-bot-re.vbrief.json
@@ -7,7 +7,7 @@
   },
   "plan": {
     "title": "Review-cycle dual-source fetch can miss late-arriving bot reviews",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Problem": "Phase 2 Step 1 of the review-cycle skill mandates dual-source fetching (`gh pr view --comments` + MCP `get_review_comments` or `gh api` fallback) and `do_not_summarize_output: true` to catch the 'Comments Outside Diff' section. Both correct. The gap: if the agent's first fetch lands BEFORE the bot has posted (e.g. T+30s after PR creation; Greptile lands at T+3-7min), both sources return zero findings. The Step 6 exit condition then evaluates against an empty review and declares 'no P0/P1 remaining' even though the bot review is still in flight. The Step 4 polling loop covers any cycle that includes a push, but the cold-start case (first review-cycle invocation on a freshly-opened PR with no fixes yet) is uncovered.",
       "Overview": "Add a `~` SHOULD rule to Phase 2 Step 1 mandating a re-fetch after a ~60s delay when the initial dual-source pass returns no bot review on the current HEAD SHA, before the Step 6 exit condition can be evaluated. Companion `⊗` MUST NOT rule against declaring exit on a single empty fetch.",
@@ -126,7 +126,7 @@
         "pr_title_suggestion": "fix(skills/review-cycle): re-fetch on cold-start to catch late-arriving bot reviews (#796)"
       }
     },
-    "updated": "2026-05-03T01:53:52Z",
+    "updated": "2026-05-03T04:38:16Z",
     "id": "796-review-cycle-late-arriving-bot-reviews",
     "planRef": "#796"
   }

--- a/vbrief/completed/2026-05-03-800-swarm-skill-prohibit-git-checkout-in-a-worktree-another-agen.vbrief.json
+++ b/vbrief/completed/2026-05-03-800-swarm-skill-prohibit-git-checkout-in-a-worktree-another-agen.vbrief.json
@@ -7,7 +7,7 @@
   },
   "plan": {
     "title": "swarm SKILL: prohibit `git checkout` in a worktree another agent owns (post-merge cleanup overreach)",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Problem": "Phase 6 Step 3 of the swarm SKILL describes post-merge `git pull origin <base-branch>` without scoping to the merger's own worktree. In multi-worktree patterns (the documented multi-agent pattern from AGENTS.md), the merging agent can `cd` into a sibling worktree another agent owns and run `git checkout master` to perform the pull -- detaching HEAD on the other agent's branch. Recurrence record: PR #797 merge session (2026-05-01) -- Agent A owned C:\\repos\\Deft\\directive on a refinement branch; Agent B (merger) owned a sibling worktree; Agent B ran `cd C:\\repos\\Deft\\directive; git checkout master --quiet` after merging its own PR. No work lost (Agent A had pushed) but recovery was retroactive, not preventative.",
       "Overview": "Add a `⊗` MUST NOT rule to Phase 6 Step 3 prohibiting `git checkout` (any branch) in a worktree the merger does not own, plus a companion `!` MUST rule that the merger MAY remove its OWN worktree and orphaned local feature branch but MUST NOT alter any other worktree's HEAD or branch state. Post-merge state-update is performed via `git fetch origin <base>` from the merger's own worktree, OR left to the human operator.",
@@ -125,7 +125,7 @@
         "pr_title_suggestion": "fix(skills/swarm): prohibit git checkout in another agent's worktree during post-merge cleanup (#800)"
       }
     },
-    "updated": "2026-05-03T01:53:52Z",
+    "updated": "2026-05-03T04:38:15Z",
     "id": "800-swarm-no-checkout-in-others-worktree",
     "planRef": "#800"
   }

--- a/vbrief/completed/2026-05-03-814-scriptspreflight-branchpy-crashes-with-unicodeencodeerror-on.vbrief.json
+++ b/vbrief/completed/2026-05-03-814-scriptspreflight-branchpy-crashes-with-unicodeencodeerror-on.vbrief.json
@@ -7,7 +7,7 @@
   },
   "plan": {
     "title": "scripts/preflight_branch.py crashes with UnicodeEncodeError on Windows (cp1252) -- blocks every commit",
-    "status": "running",
+    "status": "completed",
     "narratives": {
       "Problem": "scripts/preflight_branch.py (the pre-commit branch-protection hook installed by `task setup`, #747) prints `\\u2713` on its success path. On Windows, Python's stdout default is cp1252 (or cp437 depending on console host), neither of which has a glyph for U+2713. `codecs.charmap_encode` raises UnicodeEncodeError; the hook exits non-zero with a traceback; git aborts the commit. Crucially: the gate has ALREADY APPROVED the commit before the print fails, so the user sees a Python traceback after a successful check, which is maximally confusing. Workaround (`PYTHONIOENCODING=utf-8 git commit ...`) is undiscoverable. Reproduction captured during the #810 fixup chore commit on this Windows session.",
       "Overview": "Three coordinated changes per the issue. Change 1: force UTF-8 stdout/stderr reconfigure at the top of scripts/preflight_branch.py main() with errors='replace' as a belt-and-suspenders fallback. Change 2: audit every scripts/*.py referenced from .githooks/ and apply the same fix; pin via a NEW tests/cli/test_hooks_encoding.py contract test that wraps stdout in a cp1252 BytesIO TextIOWrapper and verifies non-ASCII print succeeds. Change 3: task setup detects cp1252 stdout at install time and warns the user with the actionable PYTHONIOENCODING fix (informational on current versions because the hooks self-reconfigure).",
@@ -140,7 +140,7 @@
         "pr_title_suggestion": "fix(scripts/preflight_branch.py): UTF-8 self-reconfigure at hook entry to unblock Windows cp1252 commits (#814)"
       }
     },
-    "updated": "2026-05-03T01:53:52Z",
+    "updated": "2026-05-03T04:38:15Z",
     "id": "814-preflight-branch-cp1252-glyph",
     "planRef": "#814"
   }


### PR DESCRIPTION
## Summary

Move all 9 Phase 1 -- Fix Now scope vBRIEFs from `vbrief/active/` to `vbrief/completed/` via `task scope:complete`, post-merge of the cohort. Per swarm SKILL Phase 5 lifecycle gate.

## Cohort PRs (chronological, all merged)

| Order | PR | Issue | Description |
|---|---|---|---|
| 1 | #844 | n/a | chore: ingest open `bug`/`adoption-blocker` issues missing from lifecycle (#784, #796, #800, #814) |
| 2 | #846 | #814 | fix(scripts/preflight_branch.py): UTF-8 self-reconfigure at hook entry (cp1252 unblock) |
| 3 | #850 | #794 | docs(UPGRADING): document AGENTS.md managed-section legacy migration |
| 4 | #851 | #791 | fix(run): resolve `run` against `%~dp0` in run.bat |
| 5 | #854 | #800 | fix(skills/swarm): prohibit `git checkout` in another agent's worktree |
| 6 | #859 | #796 | fix(skills/review-cycle): re-fetch on cold-start to catch late-arriving bot reviews |
| 7 | #858 | #792 | fix(cmd_doctor): add uv PATH check; drop pre-v0.20 expected_dirs |
| 8 | #860 | #793 | feat(tasks/migrate): add `migrate:preflight` aggregate; `migrate:vbrief` self-invokes it |
| 9 | #862 | #798 | feat(scripts,tasks,hooks,docs): deterministic-tier PS 5.1 non-ASCII corruption gate |
| 10 | #861 | #784 | fix(scripts/release.py): verify release tag is available before state mutation |

## Side effects

- `vbrief/PROJECT-DEFINITION.vbrief.json`: 339 scope items (unchanged total — moves only)
- `ROADMAP.md`: Phase 1 cohort relocated to `## Completed` section (auto-rendered)
- `tests/content/test_swarm_skill.py`: replaced two literal-mojibake documentation comments with escape-sequence form to satisfy the new `#798 verify:encoding` gate. The gate caught these on first run after `#862` merged — intended-purpose dogfood.

## Validation

- `task vbrief:validate`: clean (2 pre-existing SPEC/PRD warnings, unrelated)
- `task verify:encoding`: clean (832 files, 0 hits)
- `task check`: green (3815 passed, 3 skipped, 1 xfailed)

## Next step

Once this lands, this branch becomes the base for cutting **`v0.24.0`** per `skills/deft-directive-release/SKILL.md` (mix of feats #793, #796, #798 + fixes #784, #791, #792, #794, #800, #814 = minor bump).

Refs #784, #791, #792, #793, #794, #796, #798, #800, #814.
