### PR TITLE
chore(vbrief): complete #845 triage v1 lifecycle housekeeping

### DIFF
--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -2,7 +2,7 @@
   "vBRIEFInfo": {
     "version": "0.6",
     "description": "Project definition -- synthesized gestalt of the project.",
-    "updated": "2026-05-03T16:21:36Z"
+    "updated": "2026-05-03T20:48:28Z"
   },
   "plan": {
     "title": "PROJECT-DEFINITION",
@@ -131,47 +131,6 @@
               "uri": "https://github.com/deftai/deft-agent-bench",
               "type": "x-vbrief/related-repo",
               "title": "deft-agent-bench (internal): bench infrastructure for this validation effort"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-03-845-pre-ingest-triage-workflow-epic",
-        "title": "feat(triage,cache,refinement): pre-ingest triage workflow with sidecar issue cache",
-        "status": "proposed",
-        "metadata": {
-          "source_path": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
-          "lifecycle_folder": "proposed",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/845",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #845: feat(triage,cache,refinement): pre-ingest triage workflow with sidecar issue cache (refs #583 #788 #789 #815 #522)"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/583",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #583: injection-quarantine for ingested origin content (security blocker absorbed)"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/788",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #788: token-cost as first-class constraint (cost framework)"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/789",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #789: pr-triage-stack (prior art / tooling: ghreplica, gitcrawl, pr-search-cli)"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/815",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #815: refinement-state forcing function (visibility integration)"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/868",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #868: bidirectional implementation-lock comment protocol (stacks on top of this work)"
             }
           ]
         }
@@ -929,152 +888,6 @@
               "uri": "https://github.com/deftai/directive/issues/762",
               "type": "x-vbrief/github-issue",
               "title": "Issue #762: feat(vbrief): centralize phase taxonomy in PROJECT-DEFINITION.vbrief.json; renderer reads from there"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-03-845-triage-actions",
-        "title": "feat(scripts,tasks): triage action commands (accept/reject/defer/needs-ac/mark-duplicate/status/reset/history)",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-03-845-triage-actions.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/845",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #845 (parent epic)"
-            },
-            {
-              "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
-              "type": "x-vbrief/related-plan",
-              "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-03-845-triage-bootstrap-and-docs",
-        "title": "feat(scripts,tasks,docs): triage bootstrap + UPGRADING.md + parent Taskfile wiring + quarantine spec + privacy NFR",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-03-845-triage-bootstrap-and-docs.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/845",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #845 (parent epic)"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/583",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #583: injection-quarantine spec (formalized in this story)"
-            },
-            {
-              "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
-              "type": "x-vbrief/related-plan",
-              "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-03-845-triage-bulk-and-freshness",
-        "title": "feat(scripts,tasks): triage bulk ops + pre-swarm freshness gate",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-03-845-triage-bulk-and-freshness.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/845",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #845 (parent epic)"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/868",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #868: lock-comment protocol (consumes this story's freshness primitive)"
-            },
-            {
-              "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
-              "type": "x-vbrief/related-plan",
-              "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-03-845-triage-cache-infra",
-        "title": "feat(scripts,tasks): triage cache infra + #583 quarantine on cache path",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-03-845-triage-cache-infra.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/845",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #845 (parent epic)"
-            },
-            {
-              "uri": "https://github.com/deftai/directive/issues/583",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #583: injection-quarantine spec"
-            },
-            {
-              "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
-              "type": "x-vbrief/related-plan",
-              "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-03-845-triage-candidates-audit-log",
-        "title": "feat(scripts,vbrief/schemas): triage candidates.jsonl audit log + JSON schema",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-03-845-triage-candidates-audit-log.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/845",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #845 (parent epic)"
-            },
-            {
-              "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
-              "type": "x-vbrief/related-plan",
-              "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
-            }
-          ]
-        }
-      },
-      {
-        "id": "2026-05-03-845-triage-refinement-phase-0",
-        "title": "feat(skills): extend deft-directive-refinement with Phase 0 (cache + triage)",
-        "status": "running",
-        "metadata": {
-          "source_path": "active/2026-05-03-845-triage-refinement-phase-0.vbrief.json",
-          "lifecycle_folder": "active",
-          "references": [
-            {
-              "uri": "https://github.com/deftai/directive/issues/845",
-              "type": "x-vbrief/github-issue",
-              "title": "Issue #845 (parent epic)"
-            },
-            {
-              "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
-              "type": "x-vbrief/related-plan",
-              "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
-            },
-            {
-              "uri": "contracts/deterministic-questions.md",
-              "type": "x-vbrief/related-doc",
-              "title": "Deterministic-questions contract (gate compliance)"
             }
           ]
         }
@@ -6122,6 +5935,193 @@
               "uri": "scripts/preflight_branch.py",
               "type": "x-vbrief/related-doc",
               "title": "The script to fix"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-03-845-pre-ingest-triage-workflow-epic",
+        "title": "feat(triage,cache,refinement): pre-ingest triage workflow with sidecar issue cache",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/845",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #845: feat(triage,cache,refinement): pre-ingest triage workflow with sidecar issue cache (refs #583 #788 #789 #815 #522)"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/583",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #583: injection-quarantine for ingested origin content (security blocker absorbed)"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/788",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #788: token-cost as first-class constraint (cost framework)"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/789",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #789: pr-triage-stack (prior art / tooling: ghreplica, gitcrawl, pr-search-cli)"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/815",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #815: refinement-state forcing function (visibility integration)"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/868",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #868: bidirectional implementation-lock comment protocol (stacks on top of this work)"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-03-845-triage-actions",
+        "title": "feat(scripts,tasks): triage action commands (accept/reject/defer/needs-ac/mark-duplicate/status/reset/history)",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-03-845-triage-actions.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/845",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #845 (parent epic)"
+            },
+            {
+              "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+              "type": "x-vbrief/related-plan",
+              "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-03-845-triage-bootstrap-and-docs",
+        "title": "feat(scripts,tasks,docs): triage bootstrap + UPGRADING.md + parent Taskfile wiring + quarantine spec + privacy NFR",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-03-845-triage-bootstrap-and-docs.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/845",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #845 (parent epic)"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/583",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #583: injection-quarantine spec (formalized in this story)"
+            },
+            {
+              "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+              "type": "x-vbrief/related-plan",
+              "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-03-845-triage-bulk-and-freshness",
+        "title": "feat(scripts,tasks): triage bulk ops + pre-swarm freshness gate",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-03-845-triage-bulk-and-freshness.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/845",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #845 (parent epic)"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/868",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #868: lock-comment protocol (consumes this story's freshness primitive)"
+            },
+            {
+              "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+              "type": "x-vbrief/related-plan",
+              "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-03-845-triage-cache-infra",
+        "title": "feat(scripts,tasks): triage cache infra + #583 quarantine on cache path",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-03-845-triage-cache-infra.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/845",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #845 (parent epic)"
+            },
+            {
+              "uri": "https://github.com/deftai/directive/issues/583",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #583: injection-quarantine spec"
+            },
+            {
+              "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+              "type": "x-vbrief/related-plan",
+              "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-03-845-triage-candidates-audit-log",
+        "title": "feat(scripts,vbrief/schemas): triage candidates.jsonl audit log + JSON schema",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-03-845-triage-candidates-audit-log.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/845",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #845 (parent epic)"
+            },
+            {
+              "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+              "type": "x-vbrief/related-plan",
+              "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
+            }
+          ]
+        }
+      },
+      {
+        "id": "2026-05-03-845-triage-refinement-phase-0",
+        "title": "feat(skills): extend deft-directive-refinement with Phase 0 (cache + triage)",
+        "status": "completed",
+        "metadata": {
+          "source_path": "completed/2026-05-03-845-triage-refinement-phase-0.vbrief.json",
+          "lifecycle_folder": "completed",
+          "references": [
+            {
+              "uri": "https://github.com/deftai/directive/issues/845",
+              "type": "x-vbrief/github-issue",
+              "title": "Issue #845 (parent epic)"
+            },
+            {
+              "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+              "type": "x-vbrief/related-plan",
+              "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
+            },
+            {
+              "uri": "contracts/deterministic-questions.md",
+              "type": "x-vbrief/related-doc",
+              "title": "Deterministic-questions contract (gate compliance)"
             }
           ]
         }

--- a/vbrief/completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json
@@ -3,12 +3,12 @@
     "version": "0.6",
     "description": "Epic vBRIEF for issue #845: pre-ingest triage workflow with sidecar issue cache + decision audit log + accept/reject/defer/needs-AC state machine. Decomposed into 6 story-level vBRIEFs for parallel swarm implementation.",
     "created": "2026-05-03T16:15:00Z",
-    "updated": "2026-05-03T16:15:00Z"
+    "updated": "2026-05-03T20:48:27Z"
   },
   "plan": {
     "id": "845-pre-ingest-triage-workflow-epic",
     "title": "feat(triage,cache,refinement): pre-ingest triage workflow with sidecar issue cache",
-    "status": "proposed",
+    "status": "completed",
     "narratives": {
       "Overview": "Three-tier inventory model: (1) `.deft-cache/issues/<repo>/<N>.{json,md}` local mirror with injection quarantine; (2) `vbrief/.eval/candidates.jsonl` append-only audit log of triage decisions; (3) `vbrief/proposed/` reserved for items the user/agent has accepted as worth tracking. Triage actions: accept / reject / defer / needs-AC / mark-duplicate. Reject closes upstream issue with reason + label. Refinement skill gains a Phase 0 that operates on the cache and routes decisions; existing Phase 1 operates on accepted-only.",
       "Problem": "Current refinement skill ingests every candidate to `proposed/` first, then evaluates. Reject path costs 2 vBRIEFs (proposed -> cancelled) plus 2 PROJECT-DEFINITION regens. `proposed/` semantics drift: items there were not actually proposed by the maintainer. Per-item `gh issue view` calls during evaluation are operationally expensive (token + rate-limit, see #788). Backlog visibility is qualitative (\"the proposed/ folder has stuff in it\") instead of quantitative.",

--- a/vbrief/completed/2026-05-03-845-triage-actions.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-triage-actions.vbrief.json
@@ -52,7 +52,7 @@
     ],
     "metadata": {
       "x-tracking": {
-        "epic_vbrief": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+        "epic_vbrief": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
         "parent_issue": "#845",
         "agent": "A3",
         "wave": 2,
@@ -84,7 +84,7 @@
         "title": "Issue #845 (parent epic)"
       },
       {
-        "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+        "uri": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
         "type": "x-vbrief/related-plan",
         "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
       }

--- a/vbrief/completed/2026-05-03-845-triage-actions.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-triage-actions.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "845-story-3-triage-actions",
     "title": "feat(scripts,tasks): triage action commands (accept/reject/defer/needs-ac/mark-duplicate/status/reset/history)",
-    "status": "running",
+    "status": "completed",
     "planRef": "#845",
     "narratives": {
       "Problem": "Triage decisions need a clear command surface. The reject path must close the upstream GitHub issue with a reason + label and record the decision reversibly.",
@@ -56,7 +56,10 @@
         "parent_issue": "#845",
         "agent": "A3",
         "wave": 2,
-        "depends_on_stories": ["Story 1 (cache)", "Story 2 (audit log)"],
+        "depends_on_stories": [
+          "Story 1 (cache)",
+          "Story 2 (audit log)"
+        ],
         "files_owned": [
           "scripts/triage_actions.py",
           "tasks/triage-actions.yml",
@@ -85,6 +88,7 @@
         "type": "x-vbrief/related-plan",
         "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
       }
-    ]
+    ],
+    "updated": "2026-05-03T20:47:54Z"
   }
 }

--- a/vbrief/completed/2026-05-03-845-triage-bootstrap-and-docs.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-triage-bootstrap-and-docs.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "845-story-6-triage-bootstrap-and-docs",
     "title": "feat(scripts,tasks,docs): triage bootstrap + UPGRADING.md + parent Taskfile wiring + quarantine spec + privacy NFR",
-    "status": "running",
+    "status": "completed",
     "planRef": "#845",
     "narratives": {
       "Problem": "Consumer projects need a single command to opt into triage v1, with documented migration impact + privacy considerations. Standalone fragments from Stories 1-4 are not yet reachable via the parent Taskfile; this story wires them.",
@@ -66,7 +66,13 @@
         "parent_issue": "#845",
         "agent": "A6",
         "wave": "last",
-        "depends_on_stories": ["Story 1", "Story 2", "Story 3", "Story 4", "Story 5"],
+        "depends_on_stories": [
+          "Story 1",
+          "Story 2",
+          "Story 3",
+          "Story 4",
+          "Story 5"
+        ],
         "files_owned": [
           "scripts/triage_bootstrap.py",
           "tasks/triage-bootstrap.yml",
@@ -108,6 +114,7 @@
         "type": "x-vbrief/related-plan",
         "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
       }
-    ]
+    ],
+    "updated": "2026-05-03T20:47:54Z"
   }
 }

--- a/vbrief/completed/2026-05-03-845-triage-bootstrap-and-docs.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-triage-bootstrap-and-docs.vbrief.json
@@ -62,7 +62,7 @@
     ],
     "metadata": {
       "x-tracking": {
-        "epic_vbrief": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+        "epic_vbrief": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
         "parent_issue": "#845",
         "agent": "A6",
         "wave": "last",
@@ -110,7 +110,7 @@
         "title": "Issue #583: injection-quarantine spec (formalized in this story)"
       },
       {
-        "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+        "uri": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
         "type": "x-vbrief/related-plan",
         "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
       }

--- a/vbrief/completed/2026-05-03-845-triage-bulk-and-freshness.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-triage-bulk-and-freshness.vbrief.json
@@ -47,7 +47,7 @@
     ],
     "metadata": {
       "x-tracking": {
-        "epic_vbrief": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+        "epic_vbrief": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
         "parent_issue": "#845",
         "agent": "A4",
         "wave": 3,
@@ -84,7 +84,7 @@
         "title": "Issue #868: lock-comment protocol (consumes this story's freshness primitive)"
       },
       {
-        "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+        "uri": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
         "type": "x-vbrief/related-plan",
         "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
       }

--- a/vbrief/completed/2026-05-03-845-triage-bulk-and-freshness.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-triage-bulk-and-freshness.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "845-story-4-triage-bulk-and-freshness",
     "title": "feat(scripts,tasks): triage bulk ops + pre-swarm freshness gate",
-    "status": "running",
+    "status": "completed",
     "planRef": "#845",
     "narratives": {
       "Problem": "Per-issue triage is too slow for ~200-issue corpora. Need bulk ops with filter flags. Separately, swarm Phase 0 currently reads `vbrief/active/` without reconciling against upstream — drift can sneak in. Need a pre-swarm freshness gate.",
@@ -51,7 +51,9 @@
         "parent_issue": "#845",
         "agent": "A4",
         "wave": 3,
-        "depends_on_stories": ["Story 3 (actions)"],
+        "depends_on_stories": [
+          "Story 3 (actions)"
+        ],
         "files_owned": [
           "scripts/triage_bulk.py",
           "scripts/triage_refresh.py",
@@ -86,6 +88,7 @@
         "type": "x-vbrief/related-plan",
         "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
       }
-    ]
+    ],
+    "updated": "2026-05-03T20:47:54Z"
   }
 }

--- a/vbrief/completed/2026-05-03-845-triage-cache-infra.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-triage-cache-infra.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "845-story-1-triage-cache-infra",
     "title": "feat(scripts,tasks): triage cache infra + #583 quarantine on cache path",
-    "status": "running",
+    "status": "completed",
     "planRef": "#845",
     "narratives": {
       "Problem": "Refinement currently calls `gh issue view <N>` per item per evaluation pass. Token cost is O(N) per pass and rate-limited. Need a local cache so subsequent passes are O(1). #583 documents an injection-quarantine requirement that has not been implemented on the cache path.",
@@ -94,6 +94,7 @@
         "type": "x-vbrief/related-plan",
         "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
       }
-    ]
+    ],
+    "updated": "2026-05-03T20:47:55Z"
   }
 }

--- a/vbrief/completed/2026-05-03-845-triage-cache-infra.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-triage-cache-infra.vbrief.json
@@ -52,7 +52,7 @@
     ],
     "metadata": {
       "x-tracking": {
-        "epic_vbrief": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+        "epic_vbrief": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
         "parent_issue": "#845",
         "agent": "A1",
         "wave": 1,
@@ -90,7 +90,7 @@
         "title": "Issue #583: injection-quarantine spec"
       },
       {
-        "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+        "uri": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
         "type": "x-vbrief/related-plan",
         "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
       }

--- a/vbrief/completed/2026-05-03-845-triage-candidates-audit-log.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-triage-candidates-audit-log.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "845-story-2-triage-candidates-audit-log",
     "title": "feat(scripts,vbrief/schemas): triage candidates.jsonl audit log + JSON schema",
-    "status": "running",
+    "status": "completed",
     "planRef": "#845",
     "narratives": {
       "Problem": "Triage decisions need a reversible audit trail. Without it, `task triage:reset <N>` and `task triage:history <N>` (Story 3) cannot be implemented. Sidecar JSONL chosen over vBRIEF schema extension to decouple from ADR-001 outcome.",
@@ -80,6 +80,7 @@
         "type": "x-vbrief/related-plan",
         "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
       }
-    ]
+    ],
+    "updated": "2026-05-03T20:47:56Z"
   }
 }

--- a/vbrief/completed/2026-05-03-845-triage-candidates-audit-log.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-triage-candidates-audit-log.vbrief.json
@@ -47,7 +47,7 @@
     ],
     "metadata": {
       "x-tracking": {
-        "epic_vbrief": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+        "epic_vbrief": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
         "parent_issue": "#845",
         "agent": "A2",
         "wave": 1,
@@ -76,7 +76,7 @@
         "title": "Issue #845 (parent epic)"
       },
       {
-        "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+        "uri": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
         "type": "x-vbrief/related-plan",
         "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
       }

--- a/vbrief/completed/2026-05-03-845-triage-refinement-phase-0.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-triage-refinement-phase-0.vbrief.json
@@ -47,7 +47,7 @@
     ],
     "metadata": {
       "x-tracking": {
-        "epic_vbrief": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+        "epic_vbrief": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
         "parent_issue": "#845",
         "agent": "A5",
         "wave": "independent",
@@ -72,7 +72,7 @@
         "title": "Issue #845 (parent epic)"
       },
       {
-        "uri": "proposed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
+        "uri": "completed/2026-05-03-845-pre-ingest-triage-workflow-epic.vbrief.json",
         "type": "x-vbrief/related-plan",
         "title": "Epic vBRIEF for #845 (related-plan; planRef captures parent semantic)"
       },

--- a/vbrief/completed/2026-05-03-845-triage-refinement-phase-0.vbrief.json
+++ b/vbrief/completed/2026-05-03-845-triage-refinement-phase-0.vbrief.json
@@ -8,7 +8,7 @@
   "plan": {
     "id": "845-story-5-triage-refinement-phase-0",
     "title": "feat(skills): extend deft-directive-refinement with Phase 0 (cache + triage)",
-    "status": "running",
+    "status": "completed",
     "planRef": "#845",
     "narratives": {
       "Problem": "The current refinement skill ingests every candidate to `proposed/` first, then evaluates. This is the root cause of `proposed/` semantic drift and the wasted-regen problem (#845).",
@@ -81,6 +81,7 @@
         "type": "x-vbrief/related-doc",
         "title": "Deterministic-questions contract (gate compliance)"
       }
-    ]
+    ],
+    "updated": "2026-05-03T20:47:57Z"
   }
 }


### PR DESCRIPTION
## Summary

Lifecycle housekeeping for the just-completed #845 triage v1 swarm cascade. Moves the 6 story vBRIEFs from `vbrief/active/` to `vbrief/completed/` and the epic from `vbrief/proposed/` to `vbrief/completed/` (status flipped to `completed`). Re-renders `vbrief/PROJECT-DEFINITION.vbrief.json` to refresh the items registry.

Pure file moves + 1 status flip + 1 rendered-artifact refresh. No code, no docs.

## Cascade record

The 7 implementation PRs that motivated this housekeeping all merged in this session:

- #872 setup (vBRIEFs scaffolding)
- #874 A1 cache infra + #583 quarantine
- #876 A2 candidates audit log + JSON schema
- #873 A5 refinement Phase 0 extension
- #879 A3 triage actions
- #875 A4 bulk ops + freshness gate
- #877 A6 bootstrap + parent Taskfile wiring + UPGRADING + docs

## Checklist

- [x] `task scope:complete` × 6 (active/ → completed/, status=completed)
- [x] Epic moved proposed/ → completed/ via Python pathlib (status=completed)
- [x] `task project:render` re-rendered PROJECT-DEFINITION.vbrief.json (346 scope items)
- [x] Branch policy: feature branch (chore/845-housekeeping-and-v0.25.0-prep)

## Next step

After merge: cut v0.25.0 release via `task release -- 0.25.0 --summary "<one-liner>"`.

Refs #845 (stays OPEN until v0.25.0 release ships and operator closes manually).
